### PR TITLE
Drop checking for optimal solution in solve!

### DIFF
--- a/src/solution.jl
+++ b/src/solution.jl
@@ -27,11 +27,9 @@ function solve!(problem::Problem, m::MathProgBase.AbstractMathProgModel=ECOS.ECO
   problem.optval = problem.solution.optval
   problem.status = problem.solution.status
 
-  if problem.status == :Optimal
-    populate_variables!(problem, variable_index)
-    if problem.solution.dual
-      populate_constraints!(problem, eq_constr_index, ineq_constr_index)
-    end
+  populate_variables!(problem, variable_index)
+  if problem.solution.dual
+    populate_constraints!(problem, eq_constr_index, ineq_constr_index)
   end
 end
 


### PR DESCRIPTION
The check for optimality in solve! is something that can be done by user code.  Dropping the check for optimality in solve! allows the values that the solver found (regardless of their meaning) to be exposed to the user after solve! has finished.

All tests in the tests directory still pass after this change, so it seems like this is more or less a completely "cosmetic" commit.  

Thanks!
