### PR TITLE
test all solvers on the system, allow user to change default solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
 script:
   - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("Convex"))`); Pkg.pin("Convex"); Pkg.resolve()'
   - julia -e 'using Convex; @assert isdefined(:Convex); @assert typeof(Convex) === Module'
-  - if [ $JULIAVERSION = "julianightlies" ]; then julia --code-coverage test/run_tests.jl; fi
-  - if [ $JULIAVERSION = "juliareleases" ]; then julia test/run_tests.jl; fi
+  - if [ $JULIAVERSION = "julianightlies" ]; then julia --code-coverage test/run_tests_all_solvers.jl; fi
+  - if [ $JULIAVERSION = "juliareleases" ]; then julia test/run_tests_all_solvers.jl; fi
 after_success:
   - julia -e 'cd(Pkg.dir("Convex")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
 

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -12,6 +12,7 @@ include("constraints/soc_constraints.jl")
 include("constraints/exp_constraints.jl")
 include("constraints/sdp_constraints.jl")
 include("problems.jl")
+include("solver_info.jl")
 include("solution.jl")
 
 ### affine atoms

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -1,25 +1,8 @@
 import MathProgBase
 export solve!
 
-default_model = nothing
-if isdir(Pkg.dir("ECOS"))
-  using ECOS
-  default_model = ECOS.ECOSMathProgModel
-end
-if isdir(Pkg.dir("SCS"))
-  using SCS
-  if default_model == nothing
-    default_model = SCS.SCSMathProgModel
-  end
-end
-
-if default_model == nothing
-  error("You have neither ECOS.jl nor SCS.jl installed. Must have at least one of these solvers.")
-end
-
-# function solve!(problem::Problem, m::MathProgBase.AbstractMathProgModel=SCS.SCSMathProgModel())
-function solve!(problem::Problem, 
-                m::MathProgBase.AbstractMathProgModel=ECOS.ECOSMathProgModel(); 
+function solve!(problem::Problem,
+                m::MathProgBase.AbstractMathProgModel=DEFAULT_SOLVER();
                 warmstart=true)
 
   c, A, b, cones, var_to_ranges, vartypes = conic_problem(problem)
@@ -55,8 +38,8 @@ function solve!(problem::Problem,
   # get the primal (and possibly dual) solution
   try
     dual = MathProgBase.getconicdual(m)
-    problem.solution = Solution(MathProgBase.getsolution(m), dual, 
-                                MathProgBase.status(m), MathProgBase.getobjval(m))    
+    problem.solution = Solution(MathProgBase.getsolution(m), dual,
+                                MathProgBase.status(m), MathProgBase.getobjval(m))
   catch
     problem.solution = Solution(MathProgBase.getsolution(m),
                                 MathProgBase.status(m), MathProgBase.getobjval(m))

--- a/src/solver_info.jl
+++ b/src/solver_info.jl
@@ -1,0 +1,68 @@
+export can_solve_mip, can_solve_sdp, DEFAULT_SOLVER
+export set_default_solver, get_default_solver
+
+global DEFAULT_SOLVER = nothing
+
+if isdir(Pkg.dir("ECOS"))
+  using ECOS
+  DEFAULT_SOLVER = ECOSSolver
+end
+
+if isdir(Pkg.dir("SCS")) && DEFAULT_SOLVER == nothing
+  using SCS
+  DEFAULT_SOLVER = SCS.SCSMathProgModel
+end
+if isdir(Pkg.dir("Gurobi")) && DEFAULT_SOLVER == nothing
+  using Gurobi
+  DEFAULT_SOLVER = GurobiSolver
+end
+if isdir(Pkg.dir("Mosek")) && DEFAULT_SOLVER == nothing
+  using Mosek
+  DEFAULT_SOLVER = MosekSolver
+end
+
+if DEFAULT_SOLVER == nothing
+  error("You have any of ECOS.jl, SCS.jl, Mosek.jl or Gurobi.jl installed. Must have at least one of these solvers.")
+end
+
+function set_default_solver(solver)
+  global DEFAULT_SOLVER
+  DEFAULT_SOLVER = solver
+end
+
+function get_default_solver()
+  return DEFAULT_SOLVER
+end
+
+function can_solve_mip(solver)
+  name = solver.name.name
+  if name == :GurobiSolver || name == :MosekSolver || name == :GLPKSolverMIP
+    return true
+  else
+    info("Only GurobiSolver, MosekSolver and GLPKSolverMIP can solve mixed integer programs")
+    return false
+  end
+end
+
+function can_solve_exp(solver)
+  name = solver.name.name
+  if name == :SCSSolver || name == :SCSMathProgModel #|| name == :MosekSolver
+    return true
+  else
+    info("Only SCSSolver and SCSMathProgModel can solve exponential programs")
+    # info("Only SCSSolver, MosekSolver and SCSMathProgModel can solve exponential programs")
+    return false
+  end
+end
+
+function can_solve_sdp(solver)
+  name = solver.name.name
+  if name == :SCSSolver || name == :SCSMathProgModel #|| name == :MosekSolver
+    return true
+  else
+    info("Only SCSSolver and SCSMathProgModel can solve semidefinite programs")
+    # info("Only SCSSolver, MosekSolver and SCSMathProgModel can solve semidefinite programs")
+    return false
+  end
+end
+

--- a/test/run_tests.jl
+++ b/test/run_tests.jl
@@ -1,3 +1,5 @@
+using Convex
+
 tests = ["test.jl",
          "test2.jl"]
 tests_scs = ["test_exp.jl",
@@ -11,14 +13,18 @@ for curtest in tests
     include(curtest)
 end
 
-if isdir(Pkg.dir("SCS"))
+if can_solve_sdp(DEFAULT_SOLVER)
 	for curtest in tests_scs
     info(" Test: $(curtest)")
     include(curtest)
 	end
 end
 
-if isdir(Pkg.dir("GLPK")) && isdir(Pkg.dir("GLPKMathProgInterface"))
+# The following syntax can be used to solve it using other solvers
+# using Gurobi
+# set_default_solver(GurobiSolver)
+
+if can_solve_mip(DEFAULT_SOLVER)
 	for curtest in tests_glpk
     info(" Test: $(curtest)")
     include(curtest)

--- a/test/run_tests_all_solvers.jl
+++ b/test/run_tests_all_solvers.jl
@@ -1,0 +1,28 @@
+using Convex
+solvers = Any[]
+
+if isdir(Pkg.dir("ECOS"))
+    using ECOS
+    push!(solvers, ECOSSolver)
+end
+
+if isdir(Pkg.dir("SCS"))
+    using SCS
+    push!(solvers, SCSSolver)
+end
+
+if isdir(Pkg.dir("Gurobi"))
+    using Gurobi
+    push!(solvers, GurobiSolver)
+end
+
+if isdir(Pkg.dir("Mosek"))
+    using Mosek
+    push!(solvers, MosekSolver)
+end
+
+for solver in solvers
+    set_default_solver(solver)
+    println("Running tests with $(solver):")
+    include("run_tests.jl")
+end

--- a/test/test_exp.jl
+++ b/test/test_exp.jl
@@ -1,49 +1,50 @@
 using Base.Test
 using Convex
+using SCS
 
 TOL = 1e-2
 
 # exp
 y = Variable()
 p = minimize(exp(y), y>=0)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 1 TOL
 
 y = Variable()
 p = minimize(exp(y), y>=1)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval exp(1) TOL
 
 # log
 y = Variable()
 p = maximize(log(y), y<=1)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 0 TOL
 
 y = Variable()
 p = maximize(log(y), y<=2)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval log(2) TOL
 
 y = Variable()
 p = maximize(log(y), [y<=2, exp(y)<=10])
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval log(2) TOL
 
 # multidimensional exp
 y = Variable(5)
 p = minimize(sum(exp(y)), y>=0)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 5 TOL
 
 
 y = Variable(5)
 p = minimize(sum(exp(y)), y>=0)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 5 TOL
 
 # logsumexp
 y = Variable(5);
 p = minimize(logsumexp(y), y>=1);
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval log(exp(1)*5) TOL

--- a/test/test_int.jl
+++ b/test/test_int.jl
@@ -1,12 +1,15 @@
 using Base.Test
 using Convex
-using GLPKMathProgInterface
-# using Gurobi
-
 TOL = 1e-2
 
-MIPsolver() = GLPKSolverMIP() # or GurobiSolver()
-LPsolver() = GLPKSolverLP() # or GurobiSolver()
+LPsolver() = DEFAULT_SOLVER()
+
+if !can_solve_mip(DEFAULT_SOLVER)
+	using GLPKMathProgInterface
+	MIPsolver() = GLPKSolverMIP()
+else
+	MIPsolver() = DEFAULT_SOLVER()
+end
 
 # LP fallback interface
 x = Variable()

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -6,62 +6,61 @@ TOL = 1e-2
 # SDP variables
 y = Variable((2,2), :Semidefinite)
 p = minimize(y[1,1])
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 0 TOL
 
 # SDP variables twice
 y = Variable((3,3), :Semidefinite)
 p = minimize(y[1,1], y[2,2]==1)
-m = SCS.SCSMathProgModel()
-solve!(p, m)
+solve!(p)
 @test_approx_eq_eps p.optval 0 TOL
 
 # Solution is obtained as y[2,2] -> infinity
 y = Variable((2, 2), :Semidefinite)
 p = minimize(y[1, 1], y[1, 2] == 1)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 0 TOL
 
 # SDP variables
 y = Semidefinite(3)
 p = minimize(sum(diag(y)), y[1, 1] == 1)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 1 TOL
 
 # SDP constraints
 x = Variable(Positive())
 y = Variable((3, 3))
 p = minimize(x + y[1, 1], isposdef(y), x >= 1, y[2, 1] == 1)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 1 TOL
 
 x = Variable(Positive())
 y = Semidefinite(3)
 p = minimize(y[1, 2], y[2, 1] == 1)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 1 TOL
 
 # Not symmetric
 x = Variable(Positive())
 y = Semidefinite(3, is_symmetric=false)
 p = minimize(y[1, 2], y[2, 1] == 1, y[1, 2] >= -1000)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval -1000 TOL
 
 # trace
 y = Variable((3, 3), :Semidefinite)
 p = minimize(trace(y), y[2,1]<=4, y[2,2]>=3)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 3 TOL
 
 # nuclear norm XXX should work when hcat and vcat do
 y = Semidefinite(3)
 p = minimize(nuclear_norm(y), y[2,1]<=4, y[2,2]>=3, y[3,3]<=2)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 3 TOL
 
 # operator norm XXX should work when hcat and vcat do
 y = Variable((3,3))
 p = minimize(operator_norm(y), y[2,1]<=4, y[2,2]>=3, sum(y)>=12)
-solve!(p, SCS.SCSMathProgModel())
+solve!(p)
 @test_approx_eq_eps p.optval 4 TOL


### PR DESCRIPTION
1. `get_default_solver` and `set_default_solver` can be used to retrieve the current default solver.
2.  `can_solve_mip` and `can_solve_sdp` can be used to see if a solver supports those operations. So far Mosek, Gurobi and GLPK support MIPs and only SCS supports SDPs/ exponential cones.
3. We can use `include test/run_tests_all_solvers.jl` to run every test a solver supports.
4. We can use `include test/run_tests.jl` to run all the tests supported by the current default solver.
5. Including a test file directly does not check to see if the solver supports those cones.
