### PR TITLE
quad_form fails for certain matrices

### DIFF
--- a/src/atoms/second_order_cone/quad_form.jl
+++ b/src/atoms/second_order_cone/quad_form.jl
@@ -28,6 +28,6 @@ function quad_form(x::AbstractExpr, A::Value)
     error("Quadratic forms supported only for semidefinite matrices")
   end
 
-  P = sqrtm(full(factor * A))
+  P = real(sqrtm(full(factor * A)))
   return factor * square(norm_2(P * x))
 end


### PR DESCRIPTION
Quadform fails for certain matrices that are positive semi-definite. The sqrtm function sometimes returns a complex matrix, with all imaginary parts 0. Truncating the imaginary part solves that problem.
![screenshot from 2014-12-04 01 26 37](https://cloud.githubusercontent.com/assets/1855120/5296085/b5ba87b6-7b54-11e4-8d43-b554854a5c54.png)
