### PR TITLE
WIP: Use FillArrays and LazyArrays to reduce memory footprint

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.7
 MathProgBase 0.7 0.8
 DataStructures
+LazyArrays
+FillArrays

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -4,6 +4,8 @@ module Convex
 import DataStructures
 using LinearAlgebra
 using SparseArrays
+using FillArrays
+using LazyArrays
 
 global DEFAULT_SOLVER = nothing
 ### modeling framework

--- a/src/atoms/affine/conv.jl
+++ b/src/atoms/affine/conv.jl
@@ -11,7 +11,7 @@ function conv(x::Value, y::AbstractExpr)
     end
     m = length(x)
     n = y.size[1]
-    X = spzeros(m+n - 1, n)
+    X = zeros(m+n - 1, n)
     for i = 1:n
         X[i:m+i-1, i] = x
     end

--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -83,7 +83,7 @@ function conic_form!(x::DiagAtom, unique_conic_forms::UniqueConicForms=UniqueCon
             sz_diag = Base.min(num_rows + k, num_cols)
         end
 
-        select_diag = spzeros(sz_diag, length(x.children[1]))
+        select_diag = zeros(sz_diag, length(x.children[1]))
         for i in 1:sz_diag
             select_diag[i, start_index] = 1
             start_index += num_rows + 1

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -158,16 +158,16 @@ function conic_form!(x::DotMultiplyAtom, unique_conic_forms::UniqueConicForms=Un
         # promote the size of the coefficient matrix, so eg
         # 3 .* x
         # works regardless of the size of x
-        coeff = x.children[1].value .* ones(size(x.children[2]))
+        coeff = x.children[1].value .* Ones(size(x.children[2]))
         # promote the size of the variable
         # we've previously ensured neither x nor y is 1x1
         # and that the sizes are compatible,
         # so if the sizes aren't equal the smaller one is size 1
         var = x.children[2]
         if size(var, 1) < size(coeff, 1)
-            var = ones(size(coeff, 1)) * var
+            var = Ones(size(coeff, 1)) * var
         elseif size(var, 2) < size(coeff, 2)
-            var = var * ones(1, size(coeff, 1))
+            var = var * Ones(1, size(coeff, 1))
         end
 
         const_multiplier = spdiagm(0 => vec(coeff))
@@ -181,9 +181,9 @@ function broadcasted(::typeof(*), x::Constant, y::AbstractExpr)
     if x.size == (1, 1) || y.size == (1, 1)
         return x * y
     elseif size(y, 1) < size(x, 1) && size(y, 1) == 1
-        return DotMultiplyAtom(x, ones(size(x, 1)) * y)
+        return DotMultiplyAtom(x, Ones(size(x, 1)) * y)
     elseif size(y, 2) < size(x, 2) && size(y, 2) == 1
-        return DotMultiplyAtom(x, y * ones(1, size(x, 1)))
+        return DotMultiplyAtom(x, y * Ones(1, size(x, 1)))
     else
         return DotMultiplyAtom(x, y)
     end

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -82,11 +82,11 @@ function conic_form!(x::MultiplyAtom, unique_conic_forms::UniqueConicForms=Uniqu
         # left matrix multiplication
         elseif x.children[1].head == :constant
             objective = conic_form!(x.children[2], unique_conic_forms)
-            objective = kron(sparse(1.0I, x.size[2], x.size[2]), x.children[1].value) * objective
+            objective = Kron(Eye{Float64}(size(x, 2)), x.children[1].value) * objective
         # right matrix multiplication
         else
             objective = conic_form!(x.children[1], unique_conic_forms)
-            objective = kron(x.children[2].value', sparse(1.0I, x.size[1], x.size[1])) * objective
+            objective = Kron(x.children[2].value', Eye{Float64}(size(x, 1))) * objective
         end
         cache_conic_form!(unique_conic_forms, x, objective)
     end

--- a/src/atoms/affine/partialtrace.jl
+++ b/src/atoms/affine/partialtrace.jl
@@ -44,19 +44,19 @@ function evaluate(x::PartialTraceAtom)
 
     subsystem = function(sys)
         function term(ρ, j::Int)
-            a = sparse(1.0I, 1, 1)
-            b = sparse(1.0I, 1, 1)
+            a = Eye{Float64}(1)
+            b = Eye{Float64}(1)
             i_sys = 1
             for dim in dims
                 if i_sys == sys
                 # create a vector that is only 1 at its jth component
-                v = spzeros(dim, 1);
-                v[j] = 1;
-                a = kron(a, v')
-                b = kron(b, v)
+                v = zeros(dim)
+                v[j] = 1
+                a = Kron(a, v')
+                b = Kron(b, v)
                 else
-                    a = kron(a, sparse(1.0I, dim, dim))
-                    b = kron(b, sparse(1.0I, dim, dim))
+                    a = Kron(a, Eye{Float64}(dim))
+                    b = Kron(b, Eye{Float64}(dim))
                 end
                 i_sys += 1
             end
@@ -65,12 +65,12 @@ function evaluate(x::PartialTraceAtom)
         return sum([term(ρ, j) for j in 1:dims[sys]])
     end
     sub_systems = [subsystem(i) for i in 1:length(dims)]
-    a = Matrix(1.0I, 1, 1)
+    a = Eye{Float64}(1)
     for i in 1:length(dims)
         if i == x.sys
             continue
         else
-            a = kron(a,sub_systems[i])
+            a = Kron(a,sub_systems[i])
         end
     end
     return tr(sub_systems[x.sys])*a
@@ -87,19 +87,19 @@ function conic_form!(x::PartialTraceAtom, unique_conic_forms::UniqueConicForms=U
         # in the system we want to trace out
         # This function returns every term in the sum
         function term(ρ, j::Int)
-            a = sparse(1.0I, 1, 1)
-            b = sparse(1.0I, 1, 1)
+            a = Eye{Float64}(1)
+            b = Eye{Float64}(1)
             i_sys = 1
             for dim in dims
                 if i_sys == sys
                     # create a vector that is only 1 at its jth component
-                    v = spzeros(dim, 1);
-                    v[j] = 1;
-                    a = kron(a, v')
-                    b = kron(b, v)
+                    v = zeros(dim)
+                    v[j] = 1
+                    a = Kron(a, v')
+                    b = Kron(b, v)
                 else
-                    a = kron(a, sparse(1.0I, dim, dim))
-                    b = kron(b, sparse(1.0I, dim, dim))
+                    a = Kron(a, Eye{Float64}(dim))
+                    b = Kron(b, Eye{Float64}(dim))
                 end
                 i_sys += 1
             end

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -96,8 +96,8 @@ function conic_form!(x::HcatAtom, unique_conic_forms::UniqueConicForms=UniqueCon
                     push!(x1_value_list, objectives[i][id][1])
                     push!(x2_value_list, objectives[i][id][2])
                 else
-                    push!(x1_value_list, spzeros(row_size, col_size))
-                    push!(x2_value_list, spzeros(row_size, col_size))
+                    push!(x1_value_list, Zeros{Float64}(row_size, col_size))
+                    push!(x2_value_list, Zeros{Float64}(row_size, col_size))
                 end
             end
             x1 = vcat(x1_value_list...)

--- a/src/atoms/affine/sum.jl
+++ b/src/atoms/affine/sum.jl
@@ -65,9 +65,9 @@ _sum(x::AbstractExpr, ::Colon) = SumAtom(x)
 
 function _sum(x::AbstractExpr, dimension::Integer)
     if dimension == 1
-        return Constant(ones(1, x.size[1]), Positive()) * x
+        return Constant(Ones(1, x.size[1]), Positive()) * x
     elseif dimension == 2
-        return x * Constant(ones(x.size[2], 1), Positive())
+        return x * Constant(Ones(x.size[2], 1), Positive())
     else
         error("Sum not implemented for dimension $dimension")
     end

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -49,7 +49,7 @@ function conic_form!(e::ExpAtom, unique_conic_forms::UniqueConicForms=UniqueConi
     if !has_conic_form(unique_conic_forms, e)
         # exp(x) \leq z  <=>  (x,ones(),z) \in ExpCone
         x = e.children[1]
-        y = Constant(ones(size(x)))
+        y = Constant(Ones(size(x)))
         z = Variable(size(x))
         objective = conic_form!(z, unique_conic_forms)
         conic_form!(ExpConstraint(x, y, z), unique_conic_forms)

--- a/src/atoms/exp_cone/log.jl
+++ b/src/atoms/exp_cone/log.jl
@@ -49,7 +49,7 @@ function conic_form!(e::LogAtom, unique_conic_forms::UniqueConicForms=UniqueConi
     if !has_conic_form(unique_conic_forms, e)
         # log(z) \geq x  <=>    (x,ones(),z) \in ExpCone
         z = e.children[1]
-        y = Constant(ones(size(z)))
+        y = Constant(Ones(size(z)))
         x = Variable(size(z))
         objective = conic_form!(x, unique_conic_forms)
         conic_form!(ExpConstraint(x, y, z), unique_conic_forms)

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -67,7 +67,7 @@ function conic_form!(x::DotSortAtom, unique_conic_forms::UniqueConicForms=Unique
         end
         mu = Variable(size(y))
         nu = Variable(size(y))
-        onesvec = ones(size(y))
+        onesvec = Ones(size(y))
         # given by the solution to
         # minimize sum(mu) + sum(nu)
         # subject to y*w' <= onesvec*nu' + mu*onesvec'

--- a/src/atoms/sdp_cone/operatornorm.jl
+++ b/src/atoms/sdp_cone/operatornorm.jl
@@ -70,7 +70,7 @@ function conic_form!(x::OperatorNormAtom, unique_conic_forms)
         A = x.children[1]
         m, n = size(A)
         t = Variable()
-        p = minimize(t, [t*sparse(1.0I, m, m) A; A' t*sparse(1.0I, n, n)] ⪰ 0)
+        p = minimize(t, [t*Eye{Float64}(m) A; A' t*Eye{Float64}(n)] ⪰ 0)
         cache_conic_form!(unique_conic_forms, x, p)
     end
     return get_conic_form(unique_conic_forms, x)

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -51,4 +51,4 @@ function conic_form!(q::GeoMeanAtom, unique_conic_forms::UniqueConicForms=Unique
 end
 
 geomean(x::AbstractExpr, y::AbstractExpr) = GeoMeanAtom(x, y)
-sqrt(x::AbstractExpr) = GeoMeanAtom(x, Constant(ones(x.size[1], x.size[2])))
+sqrt(x::AbstractExpr) = GeoMeanAtom(x, Constant(Ones(x.size[1], x.size[2])))

--- a/src/atoms/second_order_cone/qol_elementwise.jl
+++ b/src/atoms/second_order_cone/qol_elementwise.jl
@@ -49,9 +49,9 @@ end
 
 qol_elementwise(x::AbstractExpr, y::AbstractExpr) = QolElemAtom(x, y)
 
-broadcasted(::typeof(^),x::AbstractExpr,k::Int) = k==2 ? QolElemAtom(x, Constant(ones(x.size[1], x.size[2]))) : error("raising variables to powers other than 2 is not implemented")
+broadcasted(::typeof(^),x::AbstractExpr,k::Int) = k==2 ? QolElemAtom(x, Constant(Ones(x.size[1], x.size[2]))) : error("raising variables to powers other than 2 is not implemented")
 
-invpos(x::AbstractExpr) = QolElemAtom(Constant(ones(x.size[1], x.size[2])), x)
+invpos(x::AbstractExpr) = QolElemAtom(Constant(Ones(x.size[1], x.size[2])), x)
 broadcasted(::typeof(/), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x), invpos(y))
 /(x::Value, y::AbstractExpr) = size(y) == (1,1) ? MultiplyAtom(Constant(x), invpos(y)) : error("cannot divide by a variable of size $(size(y))")
 sumsquares(x::AbstractExpr) = square(norm2(x))
@@ -60,6 +60,6 @@ function square(x::AbstractExpr)
     if sign(x) == ComplexSign()
         error("Square of complex number is not DCP. Did you mean square_modulus?")
     else
-        QolElemAtom(x, Constant(ones(x.size[1], x.size[2])))
+        QolElemAtom(x, Constant(Ones(x.size[1], x.size[2])))
     end
 end

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -47,8 +47,7 @@ function conic_form!(c::SDPConstraint, unique_conic_forms::UniqueConicForms=Uniq
         # and the corresponding entries in the lower triangular part, so
         # symmetry => c.child[upperpart]
         # scale off-diagonal elements by sqrt(2)
-        rescale = sqrt(2)*tril(ones(n,n))
-        rescale[diagind(n, n)] .= 1.0
+        rescale = UnitLowerTriangular(Fill(sqrt(2), n, n))
         diagandlowerpart = findall(!iszero, vec(rescale))
         lowerpart = Array{Int}(undef, div(n*(n-1),2))
         upperpart = Array{Int}(undef, div(n*(n-1),2))

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -131,13 +131,13 @@ function conic_problem(p::Problem)
     # var_size is the sum of the lengths of all variables in the problem
     # constr_size is the sum of the lengths of all constraints in the problem
     var_size, constr_size, var_to_ranges = find_variable_ranges(constraints)
-    c = spzeros(var_size, 1)
+    c = zeros(var_size, 1)
     objective_range = var_to_ranges[objective_var_id]
     c[objective_range[1]:objective_range[2]] .= 1
 
     # slot in all of the coefficients in the conic forms into A and b
-    A = spzeros(constr_size, var_size)
-    b = spzeros(constr_size, 1)
+    A = zeros(constr_size, var_size)
+    b = zeros(constr_size, 1)
     cones = Tuple{Symbol, UnitRange{Int}}[]
     constr_index = 0
     for constraint in constraints

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -73,16 +73,15 @@ end
 
 
 function real_conic_form(x::Variable)
-    vec_size = length(x)
-    return sparse(1.0I, vec_size, vec_size)
+    return Eye{Float64}(length(x))
 end
 
 function imag_conic_form(x::Variable)
     vec_size = length(x)
     if x.sign == ComplexSign()
-        return im*sparse(1.0I, vec_size, vec_size)
+        return im * Eye{Float64}(vec_size)
     else
-        return spzeros(vec_size, vec_size)
+        return Zeros{Float64}(vec_size, vec_size)
     end
 end
 
@@ -98,7 +97,7 @@ function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueCon
             vec_size = length(x)
 
             objective[x.id_hash] = (real_conic_form(x), imag_conic_form(x))
-            objective[objectid(:constant)] = (spzeros(vec_size, 1), spzeros(vec_size, 1))
+            objective[objectid(:constant)] = (Zeros{Float64}(vec_size, 1), Zeros{Float64}(vec_size, 1))
             # placeholder values in unique constraints prevent infinite recursion depth
             cache_conic_form!(unique_conic_forms, x, objective)
             if !(x.sign == NoSign() || x.sign == ComplexSign())


### PR DESCRIPTION
Currently sparse vectors and matrices are used in many places, but this can cause memory usage to skyrocket in certain circumstances. See for example issue #254.

This change uses LazyArrays and FillArrays to express matrix structures which don't need to be mutated or immediately materialized, leading to significant memory savings.