### PR TITLE
[docs] Fix `warmstart` example

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -26,7 +26,7 @@ Warmstarting
 If you're solving the same problem many times with different values
 of a parameter, Convex.jl can initialize many solvers with the solution
 to the previous problem, which sometimes speeds up the solution time.
-This is called a **warm start**.
+This is called a **warm start**. 
 
 To use this feature,
 pass the optional argument `warmstart=true` to the `solve!` method.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -26,10 +26,12 @@ Warmstarting
 If you're solving the same problem many times with different values
 of a parameter, Convex.jl can initialize many solvers with the solution
 to the previous problem, which sometimes speeds up the solution time.
-This is called a **warm start**. 
+This is called a **warm start**.
 
 To use this feature,
 pass the optional argument `warmstart=true` to the `solve!` method.
+In the following example, we will also use `fix!`, described in the
+next section.
 ::
 
 	# initialize data
@@ -38,14 +40,15 @@ pass the optional argument `warmstart=true` to the `solve!` method.
 	x = Variable(n)
 
 	# first solve
-	lambda = 100
+	lambda = Variable(Positive())
+	fix!(lambda, 100)
 	problem = minimize(sumsquares(y - x) + lambda * sumsquares(x - 10))
 	@time solve!(problem, SCSSolver())
 
 	# now warmstart
 	# if the solver takes advantage of warmstarts, 
 	# this run will be faster
-	lambda = 105
+	fix!(lambda, 105)
 	@time solve!(problem, SCSSolver(), warmstart=true)
 
 


### PR DESCRIPTION
Changing `lambda` after the problem is constructed doesn't do anything. Resolves https://github.com/JuliaOpt/Convex.jl/issues/234 and resolves https://github.com/JuliaOpt/Convex.jl/issues/229.

Another issue is that this example doesn't seem to work very well; maybe it depends on the random choice of `y`, but when I try it, `SCS` runs out of iterations, and `Mosek` stalls but gets an optimal result. I tried a few other things but didn't find a nicer problem quickly. So it's hard to tell if the warmstart is actually speeding up the solve. Any ideas for a better problem?