### PR TITLE
fix 398

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in v0.13.5
+
+* fix [#398](https://github.com/jump-dev/Convex.jl/issues/398) by allowing `fix!`'d variables in `quadform`.
+
 # Changes in v0.13.4
 
 * You can now create your own variable types by subtyping `AbstractVariable`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Convex"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -1,4 +1,3 @@
-
 function quadform(x::Value, A::AbstractExpr)
     return x' * A * x
 end
@@ -22,4 +21,14 @@ function quadform(x::AbstractExpr, A::Value)
 
     P = real(sqrt(Matrix(factor * A)))
     return factor * square(norm2(P * x))
+end
+
+function quadform(x::AbstractExpr, A::AbstractExpr)
+    if vexity(x) == ConstVexity()
+        return quadform(evaluate(x), A)
+    elseif vexity(A) == ConstVexity()
+        return quadform(x, evaluate(A))
+    else
+        error("Either `x` or `A` must be constant in `quadform(x,A)`.")
+    end
 end

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -246,6 +246,27 @@ end
         @test p.optval ≈ 3.7713 atol=atol rtol=rtol
         @test evaluate(quadform(x, A)) ≈ -1 atol=atol rtol=rtol
     end
+
+
+    # https://github.com/jump-dev/Convex.jl/issues/398
+    n = 3
+    b = randn(n) 
+    x = Variable(n)
+    H = Semidefinite(n)
+    Hval = randn(n,n)
+    Hval .= Hval'*Hval+10*diagm(ones(n)) # symmetric positive definite
+    fix!(H, Hval)
+    p = minimize(x'b + quadform(x,H), [x >= 0]; numeric_type = T)
+    handle_problem!(p)
+
+    p2 = minimize(x'b + quadform(x,Hval), [x >= 0]; numeric_type = T)
+    handle_problem!(p2)
+
+    if test
+        @test p.optval ≈ p2.optval atol=atol rtol=rtol
+        @test evaluate(H) ≈ Hval atol=atol rtol=rtol
+    end
+
 end
 
 @add_problem socp function socp_huber_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -254,7 +254,7 @@ end
     x = Variable(n)
     H = Semidefinite(n)
     Hval = randn(n,n)
-    Hval .= Hval'*Hval+10*diagm(ones(n)) # symmetric positive definite
+    Hval .= Hval'*Hval+10*diagm(0 => ones(n)) # symmetric positive definite
     fix!(H, Hval)
     p = minimize(x'b + quadform(x,H), [x >= 0]; numeric_type = T)
     handle_problem!(p)


### PR DESCRIPTION
fix [#398](https://github.com/jump-dev/Convex.jl/issues/398) by allowing `fix!`'d variables in `quadform`