### PR TITLE
Fix `diagm(x)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in v0.13.6
+
+* fix [#401](https://github.com/jump-dev/Convex.jl/issues/401) by allowing `diagm(x)`.
+* 
 # Changes in v0.13.5
 
 * fix [#398](https://github.com/jump-dev/Convex.jl/issues/398) by allowing `fix!`'d variables in `quadform`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Convex"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.13.5"
+version = "0.13.6"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -5,7 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import LinearAlgebra.diagm, LinearAlgebra.Diagonal
 
 struct DiagMatrixAtom <: AbstractExpr
     head::Symbol
@@ -48,11 +47,12 @@ function evaluate(x::DiagMatrixAtom)
     return Diagonal(vec(evaluate(x.children[1])))
 end
 
-function diagm((d, x)::Pair{<:Integer, <:AbstractExpr})
+function LinearAlgebra.diagm((d, x)::Pair{<:Integer, <:AbstractExpr})
     d == 0 || throw(ArgumentError("only the main diagonal is supported"))
     return DiagMatrixAtom(x)
 end
-Diagonal(x::AbstractExpr) = DiagMatrixAtom(x)
+LinearAlgebra.diagm(x::AbstractExpr) = DiagMatrixAtom(x)
+LinearAlgebra.Diagonal(x::AbstractExpr) = DiagMatrixAtom(x)
 
 function conic_form!(x::DiagMatrixAtom, unique_conic_forms::UniqueConicForms)
     if !has_conic_form(unique_conic_forms, x)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -437,4 +437,9 @@ using Convex: AbstractExpr, ConicObj
         add_constraints!(p, [c, c2])
         @test length(p.constraints) == 2
     end
+
+    @testset "`diagm` (#401)" begin
+        x = Variable(3)
+        @test diagm(x) isa AbstractExpr
+    end
 end


### PR DESCRIPTION
Fixes #401. The `diagm` method accepting a vector was taken away in Julia 1.0 and added back in Julia 1.1, so we should add it back here too.