### PR TITLE
fix: hcat would fail with one block; added unary +(Sign) and +(Comple…

### DIFF
--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -84,6 +84,7 @@ struct ComplexSign <: Sign                end
 +(v::ConvexVexity, w::ConcaveVexity) = NotDcp()
 
 #+(::Convex.Positive, ::Convex.NoSign)
++(s::Sign) = s
 +(s::Positive, t::Positive) = s
 +(s::Negative, t::Negative) = s
 +(s::Positive, t::Negative) = NoSign()
@@ -95,6 +96,7 @@ struct ComplexSign <: Sign                end
 +(t::Negative, s::NoSign) = s+t
 
 # Any sign + ComplexSign = ComplexSign
++(s::ComplexSign) = s
 +(s::ComplexSign, t::ComplexSign) = s
 +(s::Sign, t::ComplexSign) = t
 +(t::ComplexSign, s::Sign) = s+t

--- a/src/problem_depot/problems/affine.jl
+++ b/src/problem_depot/problems/affine.jl
@@ -480,6 +480,26 @@ end
     end
 end
 
+@add_problem affine function affine_single_hcat_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
+    x = Variable(4, 4)
+    p = maximize(tr(hcat(x)), hcat(x) <= 2; numeric_type = T)
+
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ 8 atol=atol rtol=rtol
+    end
+end
+
+@add_problem affine function affine_single_vcat_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
+    x = Variable(4, 4)
+    p = maximize(tr(vcat(x)), vcat(x) <= 2; numeric_type = T)
+
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ 8 atol=atol rtol=rtol
+    end
+end
+
 @add_problem affine function affine_Diagonal_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     x = Variable(2, 2)
     if test


### PR DESCRIPTION
As the title says, without this I sometimes get errors when using hcat with only one item.  Why would I use hcat with only one item?  Because I'm running the solver in a function that can take a variable sized list (corresponding to something like a block matrix) and sometimes there is only one item.

Though this patch reliably fixes the problem, somehow I have struggled to come up with a standalone test case.  Let me know if a test case is important and I can try to isolate this.