### PR TITLE
Fixed nuclearnorm and sumlargesteigs for complex variables

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -106,13 +106,14 @@ Semidefinite Program Representable Functions
 An optimization problem using these functions can be solved by any SDP
 solver (including SCS and Mosek).
 
-| operation          | description                       | vexity  | slope         | notes                          |
-| ------------------ | --------------------------------- | ------- | ------------- | ------------------------------ |
-| `nuclearnorm(x)`   | sum of singular values of $x$ | convex  | not monotonic | none                           |
-| `operatornorm(x)`  | max of singular values of $x$ | convex  | not monotonic | none                           |
-| `eigmax(x)`     | max eigenvalue of $x$         | convex  | not monotonic | none                           |
-| `eigmin(x)`     | min eigenvalue of $x$         | concave | not monotonic | none                           |
-| `matrixfrac(x, P)` | $x^TP^{-1}x$                  | convex  | not monotonic | IC: P is positive semidefinite |
+| operation              | description                       | vexity  | slope         | notes                          |
+| ------------------     | --------------------------------- | ------- | ------------- | ------------------------------ |
+| `nuclearnorm(x)`       | sum of singular values of $x$     | convex  | not monotonic | none                           |
+| `operatornorm(x)`      | max of singular values of $x$     | convex  | not monotonic | none                           |
+| `eigmax(x)`            | max eigenvalue of $x$             | convex  | not monotonic | none                           |
+| `eigmin(x)`            | min eigenvalue of $x$             | concave | not monotonic | none                           |
+| `matrixfrac(x, P)`     | $x^TP^{-1}x$                      | convex  | not monotonic | IC: P is positive semidefinite |
+| `sumlargesteigs(x, k)` | sum of top $k$ eigenvalues of $x$ | convex  | not monotonic | IC: P symmetric                |
 
 Exponential + SDP representable Functions
 -----------------------------------------

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -44,6 +44,10 @@ nuclearnorm(x::AbstractExpr) = NuclearNormAtom(x)
 #            [U A; A' V] ⪰ 0
 # see eg Recht, Fazel, Parillo 2008 "Guaranteed Minimum-Rank Solutions of Linear Matrix Equations via Nuclear Norm Minimization"
 # http://arxiv.org/pdf/0706.4138v1.pdf
+#
+# The complex case is example 1.20 of Watrous' "The Theory of Quantum Information"
+# (the operator A is negated but this doesn't affect the norm)
+# https://cs.uwaterloo.ca/~watrous/TQI/TQI.pdf
 function conic_form!(x::NuclearNormAtom, unique_conic_forms)
     if !has_conic_form(unique_conic_forms, x)
         A = x.children[1]

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -48,9 +48,14 @@ function conic_form!(x::NuclearNormAtom, unique_conic_forms)
     if !has_conic_form(unique_conic_forms, x)
         A = x.children[1]
         m, n = size(A)
-        U = Variable(m,m)
-        V = Variable(n,n)
-        p = minimize(.5*(tr(U) + tr(V)), [U A; A' V] ⪰ 0)
+        if sign(A) == ComplexSign()
+            U = ComplexVariable(m,m)
+            V = ComplexVariable(n,n)
+        else
+            U = Variable(m,m)
+            V = Variable(n,n)
+        end
+        p = minimize(.5*real(tr(U) + tr(V)), [U A; A' V] ⪰ 0)
         cache_conic_form!(unique_conic_forms, x, p)
     end
     return get_conic_form(unique_conic_forms, x)

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -1,7 +1,7 @@
 #############################################################################
 # sumlargesteigs.jl
-# Handles top k eigenvalues of a symmetric positive definite matrix
-# (and imposes the constraint that its argument be PSD)
+# Handles top k eigenvalues of a symmetric or Hermitian matrix
+# (and imposes the constraint that its argument be symmetric or Hermitian)
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
@@ -64,6 +64,8 @@ function conic_form!(x::SumLargestEigs, unique_conic_forms)
             Z = Variable(n, n)
         end
         s = Variable()
+        # The two inequality constraints have the side effect of constraining A to be symmetric,
+        # since only symmetric matrices can be positive semidefinite.
         p = minimize(s*k + real(tr(Z)),
                      Z + s*Matrix(1.0I, n, n) - A ⪰ 0,
                      Z ⪰ 0)

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -27,7 +27,7 @@ struct SumLargestEigs <: AbstractExpr
 end
 
 function sign(x::SumLargestEigs)
-    return Positive()
+    return NoSign()
 end
 
 function monotonicity(x::SumLargestEigs)

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -58,11 +58,15 @@ function conic_form!(x::SumLargestEigs, unique_conic_forms)
         A = x.children[1]
         k = x.children[2]
         m, n = size(A)
-        Z = Variable(n, n)
+        if sign(A) == ComplexSign()
+            Z = ComplexVariable(n, n)
+        else
+            Z = Variable(n, n)
+        end
         s = Variable()
-        p = minimize(s*k + tr(Z),
+        p = minimize(s*k + real(tr(Z)),
                      Z + s*Matrix(1.0I, n, n) - A ⪰ 0,
-                     A ⪰ 0, Z ⪰ 0)
+                     Z ⪰ 0)
         cache_conic_form!(unique_conic_forms, x, p)
     end
     return get_conic_form(unique_conic_forms, x)

--- a/src/problem_depot/problems/affine.jl
+++ b/src/problem_depot/problems/affine.jl
@@ -500,26 +500,6 @@ end
     end
 end
 
-@add_problem affine function affine_single_hcat_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
-    x = Variable(4, 4)
-    p = maximize(tr(hcat(x)), hcat(x) <= 2; numeric_type = T)
-
-    handle_problem!(p)
-    if test
-        @test p.optval ≈ 8 atol=atol rtol=rtol
-    end
-end
-
-@add_problem affine function affine_single_vcat_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
-    x = Variable(4, 4)
-    p = maximize(tr(vcat(x)), vcat(x) <= 2; numeric_type = T)
-
-    handle_problem!(p)
-    if test
-        @test p.optval ≈ 8 atol=atol rtol=rtol
-    end
-end
-
 @add_problem affine function affine_Diagonal_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     x = Variable(2, 2)
     if test

--- a/src/problem_depot/problems/affine.jl
+++ b/src/problem_depot/problems/affine.jl
@@ -500,6 +500,26 @@ end
     end
 end
 
+@add_problem affine function affine_single_hcat_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
+    x = Variable(4, 4)
+    p = maximize(tr(hcat(x)), hcat(x) <= 2; numeric_type = T)
+
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ 8 atol=atol rtol=rtol
+    end
+end
+
+@add_problem affine function affine_single_vcat_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
+    x = Variable(4, 4)
+    p = maximize(tr(vcat(x)), vcat(x) <= 2; numeric_type = T)
+
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ 8 atol=atol rtol=rtol
+    end
+end
+
 @add_problem affine function affine_Diagonal_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     x = Variable(2, 2)
     if test

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -235,7 +235,7 @@ end
          4    5    9   4]
 
     x = ComplexVariable(4, 4)
-    p = minimize(sumlargesteigs(x, 3), [x == A]...; numeric_type = T)
+    p = minimize(sumlargesteigs(x, 3), x == A; numeric_type = T)
 
     handle_problem!(p)
 

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -229,6 +229,20 @@ end
         @test p.optval ≈ 8.4853 atol=atol rtol=rtol
     end
 
+    A = [1   -2im  3   4
+         2im  7    3im 5
+         3   -3im  2   9
+         4    5    9   4]
+
+    x = ComplexVariable(4, 4)
+    p = minimize(sumlargesteigs(x, 3), [x == A]...; numeric_type = T)
+
+    handle_problem!(p)
+
+    if test
+        @test p.optval ≈ sum(eigvals(A)[2:end]) atol=atol rtol=rtol
+    end
+
     x1 = Semidefinite(3)
     p1 = minimize(eigmax(x1), x1[1,1]>=4; numeric_type = T)
 

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -83,6 +83,21 @@ end
     end
 end
 
+@add_problem sdp function sdp_nuclear_norm_atom_complex(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
+    A = [1 2im 3 4; 4im 3im 2 1; 4 5 6 7]
+    y = ComplexVariable(3, 4)
+    p = minimize(nuclearnorm(y), y == A; numeric_type = T)
+
+    if test
+        @test vexity(p) == ConvexVexity()
+    end
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ sum(svdvals(A)) atol=atol rtol=rtol
+        @test evaluate(nuclearnorm(y)) ≈ sum(svdvals(A)) atol=atol rtol=rtol
+    end
+end
+
 @add_problem sdp function sdp_operator_norm_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     y = Variable((3,3))
     p = minimize(opnorm(y), y[2,1]<=4, y[2,2]>=3, sum(y)>=12; numeric_type = T)
@@ -94,6 +109,21 @@ end
     if test
         @test p.optval ≈ 4 atol=atol rtol=rtol
         @test evaluate(opnorm(y)) ≈ 4 atol=atol rtol=rtol
+    end
+end
+
+@add_problem sdp function sdp_operator_norm_atom_complex(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
+    A = [1 2im 3 4; 4im 3im 2 1; 4 5 6 7]
+    y = ComplexVariable(3, 4)
+    p = minimize(opnorm(y), y == A; numeric_type = T)
+
+    if test
+        @test vexity(p) == ConvexVexity()
+    end
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ maximum(svdvals(A)) atol=atol rtol=rtol
+        @test evaluate(opnorm(y)) ≈ maximum(svdvals(A)) atol=atol rtol=rtol
     end
 end
 


### PR DESCRIPTION
- nuclearnorm and sumlargesteigs now support complex variables.  This only required making the auxiliary variables complex when the input is complex.
- sumlargesteigs had a condition A ⪰ 0 which was not appropriate.  This would require the input variable to be positive semidefinite.  A unit test shows it works correctly even when A is not.
- I've also included the unit test for my recent hcat fix.  Looks like this wasn't merged into master.