### PR TITLE
fix bad conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# Changes in v0.14.3
+
+* fixed a bug where the values of variables were being converted to `Float64` even if the problem was solved in high precision. ([#427](https://github.com/jump-dev/Convex.jl/pull/427)).
+
 # Changes in v0.14.2
 
-* added lasso, ridge, and elastic net regression examples ([420](https://github.com/jump-dev/Convex.jl/pull/420)). Thanks to @PaulSoderlind!
+* added lasso, ridge, and elastic net regression examples ([#420](https://github.com/jump-dev/Convex.jl/pull/420)). Thanks to @PaulSoderlind!
 
 # Changes in v0.14.1
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Convex"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -125,18 +125,27 @@ set_value!(x::AbstractVariable, ::Nothing) = x.value = nothing
 
 function set_value!(x::AbstractVariable, v::AbstractArray)
     size(x) == size(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-    x.value = sign(x) == ComplexSign() ? convert(Array{ComplexF64}, v) : convert(Array{Float64}, v)
+    if iscomplex(x) && !(eltype(v) <: Complex)
+        v = complex.(v)
+    end
+    x.value = v
 end
 
 function set_value!(x::AbstractVariable, v::AbstractVector)
     size(x, 2) == 1 || throw(DimensionMismatch("Cannot set value of a variable of size $(size(x)) to a vector"))
     size(x, 1) == length(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-    x.value = sign(x) == ComplexSign() ? convert(Array{ComplexF64}, v) : convert(Array{Float64}, v)
+    if iscomplex(x) && !(eltype(v) <: Complex)
+        v = complex.(v)
+    end
+    x.value = v
 end
 
 function set_value!(x::AbstractVariable, v::Number)
     size(x) == (1,1) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-    x.value = sign(x) == ComplexSign() ? convert(ComplexF64, v) : convert(Float64, v)
+    if sign(x) == ComplexSign() && !(v isa Complex)
+        v = complex(v)
+    end
+    x.value = v
 end
 # End of `AbstractVariable` interface
 

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -71,6 +71,20 @@ end
         @test p isa Convex.Problem{Float64}
     end
 
+    @testset "`set_value!` doesn't convert to `Float64`" begin
+        x = Variable()
+        set_value!(x, big"1.0")
+        @test evaluate(x) isa BigFloat
+
+        x = Variable(2)
+        set_value!(x, big.([1.0, 2.0]))
+        @test evaluate(x) isa Vector{BigFloat}
+
+        x = Variable(2, 2)
+        set_value!(x, big.([1.0 2.0; 3.0 4.0]))
+        @test evaluate(x) isa Matrix{BigFloat}
+    end
+
     @testset "Show" begin
         x = Variable()
         @test sprint(show, x) == """


### PR DESCRIPTION
Fix #426 

I am not sure why we had the previous method, and I'm not totally sure this is the same (in particular, I'm not sure when `x.value` references the same array as the input to `set_value!(x, v)` with convert vs when it makes a copy). But it's definitely wrong to hardcode `Float64`s or `Complex{Float64}`s here. I'll think about this more tomorrow.