### PR TITLE
More efficient and less intrusive `quadform`

### DIFF
--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -17,7 +17,7 @@ function quadform(x::AbstractExpr, A::Value)
         error("Quadratic forms supported only for semidefinite matrices")
     end
 
-    P = real(sqrt(Hermitian(factor * A)))
+    P = sqrt(Hermitian(factor * A))
     return factor * square(norm2(P * x))
 end
 

--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -6,8 +6,8 @@ function quadform(x::AbstractExpr, A::Value)
     if length(size(A)) != 2 || size(A, 1) != size(A, 2)
         error("Quadratic form only takes square matrices")
     end
-    if !issymmetric(A)
-        error("Quadratic form only defined for symmetric matrices")
+    if !ishermitian(A)
+        error("Quadratic form only defined for Hermitian matrices")
     end
     if isposdef(A)
         factor = 1

--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -9,17 +9,15 @@ function quadform(x::AbstractExpr, A::Value)
     if !issymmetric(A)
         error("Quadratic form only defined for symmetric matrices")
     end
-    V = eigvals(Symmetric(Matrix(A)))
-
-    if all(V .>= 0)
+    if isposdef(A)
         factor = 1
-    elseif all(V .<= 0)
+    elseif isposdef(.-A)
         factor = -1
     else
         error("Quadratic forms supported only for semidefinite matrices")
     end
 
-    P = real(sqrt(Matrix(factor * A)))
+    P = real(sqrt(Hermitian(factor * A)))
     return factor * square(norm2(P * x))
 end
 

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -267,6 +267,18 @@ end
         @test evaluate(H) ≈ Hval atol=atol rtol=rtol
     end
 
+    # https://github.com/jump-dev/Convex.jl/pull/444
+    x = Variable(3)
+    a,b,c,d,e,f = rand(6)
+    M = [2 a-b*im c-d*im;
+         a+b*im 2 e-f*im
+         c+d*im e+f*im 2]
+    y = rand(3)
+    p = minimize(quadform(x-y,M); numeric_type = T)
+    if test 
+        @test evaluate(x) ≈ y
+    end
+    
 end
 
 @add_problem socp function socp_huber_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -275,8 +275,9 @@ end
          c+d*im e+f*im 2]
     y = rand(3)
     p = minimize(quadform(x-y,M); numeric_type = T)
+    handle_problem!(p)
     if test 
-        @test evaluate(x) ≈ y
+        @test evaluate(x) ≈ y atol=atol rtol=rtol
     end
     
 end


### PR DESCRIPTION
This follows this thread on discourse : https://discourse.julialang.org/t/regresion-eigvals-of-bigfloat-symmetric-matrices-does-not-work-anymore/63947

After understanding that the algorithm did not need to call eigvals, I tweaked it here: Since A is supposed to be a matrix of values, this should be equivalent while still working for weird types. 