### PR TITLE
Fixing the issue #447 and updating the examples in docstrings for run_tests() and benchmark_suite()

### DIFF
--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -40,9 +40,9 @@ end
 
 function evaluate(x::IndexAtom)
     if x.inds === nothing
-        return getindex(evaluate(x.children[1]), x.rows, x.cols)
+        return output(getindex(evaluate(x.children[1]), x.rows, x.cols)) # output() needed to convert a 1-element vector to a scalar, see the link to the Issue below.
     else
-        return getindex(evaluate(x.children[1]), x.inds)
+        return output(getindex(evaluate(x.children[1]), x.inds)) # output() needed to convert a 1-element vector to a scalar. In response to https://github.com/jump-dev/Convex.jl/issues/447.
     end
 end
 

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -39,11 +39,13 @@ function curvature(x::IndexAtom)
 end
 
 function evaluate(x::IndexAtom)
-    if x.inds === nothing
-        return output(getindex(evaluate(x.children[1]), x.rows, x.cols)) # output() needed to convert a 1-element vector to a scalar, see the link to the Issue below.
+    result = if x.inds === nothing
+        getindex(evaluate(x.children[1]), x.rows, x.cols)
     else
-        return output(getindex(evaluate(x.children[1]), x.inds)) # output() needed to convert a 1-element vector to a scalar. In response to https://github.com/jump-dev/Convex.jl/issues/447.
+        getindex(evaluate(x.children[1]), x.inds)
     end
+    # `output` needed to convert a 1-element array to a scalar (https://github.com/jump-dev/Convex.jl/issues/447)
+    return output(result)
 end
 
 function conic_form!(x::IndexAtom, unique_conic_forms::UniqueConicForms)

--- a/src/problem_depot/problem_depot.jl
+++ b/src/problem_depot/problem_depot.jl
@@ -21,9 +21,9 @@ eye(n) = Matrix{Float64}(I, n, n)
 
 A "depot" of Convex.jl problems, subdivided into categories.
 Each problem is stored as a function with the signature
-    
+
     f(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
-    
+
 where `handle_problem!` specifies what to do with the `Problem` instance
 (e.g., `solve!` it with a chosen solver), an option `test` to choose
 whether or not to test the values (assuming it has been solved),
@@ -45,10 +45,10 @@ const PROBLEMS = Dict{String, Dict{String, Function}}()
 
 """
     foreach_problem(apply::Function, [class::String],
-        problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing; 
+        problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
         exclude::Vector{Regex} = Regex[])
 
-Provides a convience method for iterating over problems in [`PROBLEMS`](@ref). 
+Provides a convience method for iterating over problems in [`PROBLEMS`](@ref).
 For each problem in [`PROBLEMS`](@ref), apply the function `apply`, which
 takes two arguments: the name of the function associated to the problem,
 and the function associated to the problem itself.
@@ -58,8 +58,8 @@ problems (`class` should satsify `class ∈ keys(PROBLEMS)`), and pass third
 argument `problems` to only allow certain problems (specified by exact names or
 regex). Use the `exclude` keyword argument to exclude problems by regex.
 """
-function foreach_problem(   apply::Function, 
-                            problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing; 
+function foreach_problem(   apply::Function,
+                            problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
                             exclude::Vector{Regex} = Regex[])
     for class in keys(PROBLEMS)
         any(occursin.(exclude, Ref(class))) && continue
@@ -67,7 +67,7 @@ function foreach_problem(   apply::Function,
     end
 end
 
-function foreach_problem(   apply::Function, 
+function foreach_problem(   apply::Function,
                             class::String,
                             problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
                             exclude::Vector{Regex} = Regex[])
@@ -85,9 +85,9 @@ end
 """
     run_tests(
         handle_problem!::Function;
-        problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing; 
+        problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
         exclude::Vector{Regex} = Regex[],
-        T=Float64, atol=1e-3, rtol=0.0, 
+        T=Float64, atol=1e-3, rtol=0.0,
     )
 
 Run a set of tests. `handle_problem!` should be a function that takes one
@@ -105,12 +105,12 @@ MathOptInterface model, but not for the actual problem data.
 
 ```julia
 run_tests(exclude=[r"mip"]) do p
-    solve!(p, SCSSolver(verbose=0))
+    solve!(p, () -> SCS.Optimizer(verbose=0))
 end
 ```
 """
-function run_tests( handle_problem!::Function, 
-                    problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing; 
+function run_tests( handle_problem!::Function,
+                    problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
                     exclude::Vector{Regex} = Regex[], T=Float64, atol=1e-3, rtol=0.0)
     push!(exclude, r"benchmark")
     for class in keys(PROBLEMS)
@@ -129,10 +129,10 @@ end
 """
     benchmark_suite(
         handle_problem!::Function,
-        problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing; 
+        problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
         exclude::Vector{Regex} = Regex[],
         test = Val(false),
-        T=Float64, atol=1e-3, rtol=0.0, 
+        T=Float64, atol=1e-3, rtol=0.0,
     )
 
 Create a benchmark_suite of benchmarks. `handle_problem!` should be a function
@@ -151,12 +151,12 @@ MathOptInterface model, but not for the actual problem data.
 
 ```julia
 benchmark_suite(exclude=[r"mip"]) do p
-    solve!(p, SCSSolver(verbose=0))
+    solve!(p, () -> SCS.Optimizer(verbose=0))
 end
 ```
 """
 function benchmark_suite(handle_problem!::Function,
-                         problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing; 
+                         problems::Union{Nothing, Vector{String}, Vector{Regex}} = nothing;
                          exclude::Vector{Regex} = Regex[],
                          T=Float64, atol=1e-3, rtol=0.0, test = Val(false))
     group = BenchmarkGroup()

--- a/src/problem_depot/problem_depot.jl
+++ b/src/problem_depot/problem_depot.jl
@@ -105,7 +105,7 @@ MathOptInterface model, but not for the actual problem data.
 
 ```julia
 run_tests(exclude=[r"mip"]) do p
-    solve!(p, () -> SCS.Optimizer(verbose=0))
+    solve!(p, SCS.Optimizer; silent_solver=true)
 end
 ```
 """
@@ -151,7 +151,7 @@ MathOptInterface model, but not for the actual problem data.
 
 ```julia
 benchmark_suite(exclude=[r"mip"]) do p
-    solve!(p, () -> SCS.Optimizer(verbose=0))
+    solve!(p, SCS.Optimizer; silent_solver=true)
 end
 ```
 """

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -1383,7 +1383,7 @@ end
 
     A = A₀ + A₁*x[1] + A₂*x[2]
 
-    p = minimize(λ,A⪯λ)
+    p = minimize(λ,A⪯λ; numeric_type=T)
 
     handle_problem!(p)
 

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -1367,7 +1367,7 @@ end
     # as a linear optimization subject to a canonical LMI (SDP) constraint:
     #
     # minimize      λ
-    # subject to    A(x)⪯λ
+    # subject to    A(x) ⪯ λ*I
     # where x is a vector in Rⁿ and the matrix function A(x) = A₀ + A₁x₁ + A₂x₂ + … + Aₙxₙ.
     #
     # Besides serving as a benchmark, it also tests the solution of the Issue
@@ -1383,7 +1383,7 @@ end
 
     A = A₀ + A₁*x[1] + A₂*x[2]
 
-    p = minimize(λ,A⪯λ; numeric_type=T)
+    p = minimize(λ,A⪯λ*eye(2); numeric_type=T)
 
     handle_problem!(p)
 

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -1388,8 +1388,8 @@ end
     handle_problem!(p)
 
     if test
-        @test λ.value ≈ 2.0 atol=atol rtol=rtol
-        @test x.value ≈ [1.0, 0.0] atol=atol rtol=rtol
-        @test evaluate(A) ≈ [2.0 2.0; 2.0 2.0] atol=atol rtol=rtol
+        @test λ.value ≈ 2.400000051025101 atol=atol rtol=rtol
+        @test x.value ≈ [3.0000000535867315, -0.4000000018585541] atol=atol rtol=rtol
+        @test evaluate(A) ≈ [2.400000046152515 -9.292770553059881e-9; -9.292770553059881e-9 2.399999957564593] atol=atol rtol=rtol
     end
 end


### PR DESCRIPTION
Fixing the issue #447 (simplifying a one-element vector or matrix to a scalar). In addition, updating the syntax for choosing the optimizers in the docstring examples for run_tests() and benchmark_suite().