### PR TITLE
Improve numerical stability of `logsumexp`

### DIFF
--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -39,8 +39,10 @@ end
 
 function evaluate(x::LogSumExpAtom)
     _x = evaluate(x.children[1])
+    @show _x
     max_x = maximum(_x)
-    return max_x .+ log(sum(exp.(_x .- max_x)))
+    @show max_x
+    return max_x + log(sum(exp.(_x - max_x)))
 end
 
 logsumexp(x::AbstractExpr) = LogSumExpAtom(x)

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -39,10 +39,8 @@ end
 
 function evaluate(x::LogSumExpAtom)
     _x = evaluate(x.children[1])
-    @show _x
     max_x = maximum(_x)
-    @show max_x
-    return max_x + log(sum(exp.(_x - max_x)))
+    return max_x + log(sum(exp.(_x .- max_x)))
 end
 
 logsumexp(x::AbstractExpr) = LogSumExpAtom(x)

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -38,7 +38,9 @@ function curvature(x::LogSumExpAtom)
 end
 
 function evaluate(x::LogSumExpAtom)
-    return log(sum(exp.(evaluate(x.children[1]))))
+    _x = evaluate(x.children[1])
+    max_x = maximum(_x)
+    return max_x .+ log(sum(exp.(_x .- max_x)))
 end
 
 logsumexp(x::AbstractExpr) = LogSumExpAtom(x)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -512,4 +512,9 @@ end
         @test_throws ErrorException quadform(x, A; assume_psd=false)
         @test quadform(x, A; assume_psd=true) isa Convex.AbstractExpr
     end
+
+    @testset "`logsumexp` stability" begin
+        v = Convex.Constant([1000, 1000, 1000])
+        @test Convex.evaluate(Convex.logsumexp(v)) ≈ 1001.098612
+    end
 end


### PR DESCRIPTION
Resolves #461.

Please refer to [this article](https://gregorygundersen.com/blog/2020/02/09/log-sum-exp/) how it makes `logsumexp` evaluation numerically stable.