### PR TITLE
remove deprecated AbstractTrees calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Convex"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -13,7 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractTrees = "0.2, 0.3"
+AbstractTrees = "0.2, 0.3, 0.4"
 BenchmarkTools = "1"
 ECOS = "1"
 GLPK = "1"

--- a/src/utilities/tree_print.jl
+++ b/src/utilities/tree_print.jl
@@ -1,12 +1,12 @@
-# This module is needed until AbstractTrees.jl#37 is fixed.
-# (PR: https://github.com/Keno/AbstractTrees.jl/pull/38)
-# because currently `print_tree` does not respect `maxdepth`.
-# This just implements the changes in the above PR.
+# This module originally existed for AbstractTrees.jl#37,
+# but has since diverged from the functionality of
+# AbstractTrees.print_tree.  It is now a separate implementation
+# of tree printing
 # Code in this file is modified from AbstractTrees.jl
 # See LICENSE for a copy of its MIT license.
 module TreePrint
 
-using AbstractTrees: printnode, treekind, IndexedTree, children
+using AbstractTrees: children, printnode
 
 # Printing
 struct TreeCharSet
@@ -83,8 +83,7 @@ function _print_tree(
     if withinds
         printnode(nodebuf, tree, inds)
     else
-        tree != roottree && isa(treekind(roottree), IndexedTree) ?
-        printnode(nodebuf, roottree[tree]) : printnode(nodebuf, tree)
+        printnode(nodebuf, tree)
     end
     str = String(take!(isa(nodebuf, IOContext) ? nodebuf.io : nodebuf))
     for (i, line) in enumerate(split(str, '\n'))
@@ -92,10 +91,8 @@ function _print_tree(
         println(io, line)
     end
     depth > maxdepth && return
-    c =
-        isa(treekind(roottree), IndexedTree) ? childindices(roottree, tree) :
-        children(roottree, tree)
-    if c !== ()
+    c = children(tree)
+    if !isempty(c)
         width = 0
         s = Iterators.Stateful(
             from === nothing ? pairs(c) : Iterators.Rest(pairs(c), from),


### PR DESCRIPTION
I've recently done a major overhaul of AbstractTrees.jl which will be part of the upcoming v0.4 release for that package.  Convex.jl is unique in that it is the only registered dependency of AbstractTrees.jl which uses the soon-to-be-deprecated functions `treekind` and `IndexedTree`.

It seems that Convex.jl contains a re-implementation of `print_tree` because of a problem that dates back to AbstractTrees.jl v0.2.  At first, I completely removed this re-implementation in favor of the current AbstractTrees implementation, but later realized that it has since diverged from `AbstractTrees.print_tree` even in v0.3.  In particular, while `maxdepth` has worked fine for a while, we do not have a `maxwidth`.  There are also some small differences in the exact printed forms.

Instead, I've removed the calls to `treekind` and `IndexedTree`.  This should be fine for all versions of AbstractTree.jl because these features were very poorly documented and almost never used (which has now been [explicitly verified](https://github.com/JuliaCollections/AbstractTrees.jl/issues/103)).