### PR TITLE
Write to file

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -60,7 +60,7 @@ export constraints, add_constraint!, set_value!, evaluate
 export Positive, Negative, ComplexSign, NoSign
 
 # Problems
-export add_constraints!, maximize, minimize, Problem, satisfy, solve!
+export add_constraints!, maximize, minimize, Problem, satisfy, solve!, write_to_file
 
 # Module level globals
 

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -60,7 +60,8 @@ export constraints, add_constraint!, set_value!, evaluate
 export Positive, Negative, ComplexSign, NoSign
 
 # Problems
-export add_constraints!, maximize, minimize, Problem, satisfy, solve!, write_to_file
+export add_constraints!,
+    maximize, minimize, Problem, satisfy, solve!, write_to_file
 
 # Module level globals
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -212,16 +212,16 @@ problem is loaded into a MathOptInterface model.
 The file format is inferred from the filename extension. Supported file
 types depend on the model type.
 """
-function write_to_file(problem::Problem{T}, filename::String) where T
+function write_to_file(problem::Problem{T}, filename::String) where {T}
     isnothing(problem.model) && throw(
         ArgumentError(
             """
             Problem has not been loaded into a MathOptInterface model; 
             call `solve!(problem, optimizer)` before writing problem to file.
-            """
-        )   
+            """,
+        ),
     )
-    dest = MOI.FileFormats.Model(filename=filename)
+    dest = MOI.FileFormats.Model(filename = filename)
     src = problem.model
     MOI.copy_to(MOI.Bridges.full_bridge_optimizer(dest, T), src)
     return MOI.write_to_file(dest, filename) # nothing

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -212,7 +212,7 @@ problem is loaded into a MathOptInterface model.
 The file format is inferred from the filename extension. Supported file
 types depend on the model type.
 """
-function write_to_file(problem::Problem, filename::String)
+function write_to_file(problem::Problem{T}, filename::String) where T
     isnothing(problem.model) && throw(
         ArgumentError(
             """
@@ -223,6 +223,6 @@ function write_to_file(problem::Problem, filename::String)
     )
     dest = MOI.FileFormats.Model(filename=filename)
     src = problem.model
-    MOI.copy_to(MOI.Bridges.full_bridge_optimizer(dest, Float64), src)
+    MOI.copy_to(MOI.Bridges.full_bridge_optimizer(dest, T), src)
     return MOI.write_to_file(dest, filename) # nothing
 end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -209,18 +209,19 @@ Write the current problem to the file at `filename`. Requires solving
 the problem at least once using [`solve!`](@ref) to ensure that the
 problem is loaded into a MathOptInterface model.
 
-Supported file types depend on the model type.
+The file format is inferred from the filename extension. Supported file
+types depend on the model type.
 """
 function write_to_file(problem::Problem, filename::String)
     isnothing(problem.model) && throw(
         ArgumentError(
             """
-            Problem has not been loaded into a MathOptInterface model; call 
-            `solve!(problem, optimizer)` before writing problem to file.
+            Problem has not been loaded into a MathOptInterface model; 
+            call `solve!(problem, optimizer)` before writing problem to file.
             """
         )   
     )
-    dest = MOI.FileFormats.Model(format = MOI.FileFormats.FORMAT_SDPA)
+    dest = MOI.FileFormats.Model(filename=filename)
     src = problem.model
     MOI.copy_to(MOI.Bridges.full_bridge_optimizer(dest, Float64), src)
     return MOI.write_to_file(dest, filename) # nothing

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -201,3 +201,27 @@ function cache_conic_form!(
     end
     return cache_conic_form!(conic_forms, x, objective)
 end
+
+"""
+    write_to_file(problem::Problem, filename::String)
+
+Write the current problem to the file at `filename`. Requires solving
+the problem at least once using [`solve!`](@ref) to ensure that the
+problem is loaded into a MathOptInterface model.
+
+Supported file types depend on the model type.
+"""
+function write_to_file(problem::Problem, filename::String)
+    isnothing(problem.model) && throw(
+        ArgumentError(
+            """
+            Problem has not been loaded into a MathOptInterface model; call 
+            `solve!(problem, optimizer)` before writing problem to file.
+            """
+        )   
+    )
+    dest = MOI.FileFormats.Model(format = MOI.FileFormats.FORMAT_SDPA)
+    src = problem.model
+    MOI.copy_to(MOI.Bridges.full_bridge_optimizer(dest, Float64), src)
+    return MOI.write_to_file(dest, filename) # nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,3 +90,7 @@ end
         end
     end
 end
+
+@testset "Write to file" begin
+    include("write_to_file.jl")
+end

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -1,0 +1,37 @@
+# Tests of the write_to_file(problem, filename) interface
+
+# Simple quadratic program
+let
+    filename, _io = Base.Filesystem.mktemp()
+
+    m, n = 5, 10
+    x = Variable(n)
+    A = randn(m, n)
+    b = randn(m)
+    problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
+
+    # Haven't solved the problem yet
+    @test_throws ArgumentError write_to_file(problem, filename)
+
+    # Make sure file is written without error
+    # Can't check correctness since we don't provide a read_to_file function
+    solve!(problem, SCS.Optimizer)
+    @test write_to_file(problem, filename) |> isnothing
+end
+
+# Eric Hanson's fancy problem from issue #395
+# https://github.com/jump-dev/Convex.jl/issues/395
+let
+    filename, _io = Base.Filesystem.mktemp()
+
+    x = HermitianSemidefinite(2)
+    problem = minimize(real(tr(x)), tr(x * [1.0 im; -im 0]) == 0, x[1, 1] == 1)
+
+    # Haven't solved the problem yet
+    @test_throws ArgumentError write_to_file(problem, filename)
+
+    # Make sure file is written without error
+    # Can't check correctness since we don't provide a read_to_file function
+    solve!(problem, SCS.Optimizer)
+    @test write_to_file(problem, filename) |> isnothing
+end

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -1,7 +1,7 @@
 # Tests of the write_to_file(problem, filename) interface
 
 # Simple quadratic program
-@testset "Simply quadratic program" begin
+@testset "Simple quadratic program (Float32 eltype)" begin
     filename, _io = Base.Filesystem.mktemp()
 
     m, n = 5, 10
@@ -29,9 +29,38 @@
     end
 end
 
+# Simple quadratic program
+@testset "Simple quadratic program (BigFloat eltype)" begin
+    filename, _io = Base.Filesystem.mktemp()
+
+    m, n = 5, 10
+    x = Variable(n)
+    A = randn(BigFloat, m, n)
+    b = randn(BigFloat, m)
+    problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
+
+    # Haven't solved the problem yet, should get an ArgumentError
+    @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
+
+    solve!(problem, SCS.Optimizer)
+
+    # Format lists pulled from source code of MOI.FileFormats.Model
+    # These are the formats that are compatible with this problem
+    format_ok = [".cbf", ".mof.json", ".dat-s", ".sdpa"]
+    for ext in format_ok
+        @test write_to_file(problem, filename * ext) |> isnothing
+    end
+
+    # These formats are not compatible; the specific exception varies
+    format_bad = [".lp", ".mps", ".rew", ".nl"]
+    for ext in format_bad
+        @test_throws Exception write_to_file(problem, filename * ext)
+    end
+end
+
 # Eric Hanson's fancy problem from issue #395
 # https://github.com/jump-dev/Convex.jl/issues/395
-@testset "Fancy SDP" begin
+@testset "Fancy SDP (Float64 eltype)" begin
     filename, _io = Base.Filesystem.mktemp()
 
     x = HermitianSemidefinite(2)

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -1,7 +1,9 @@
 # Tests of the write_to_file(problem, filename) interface
 
 # Simple quadratic program
+# Can be written in any of the formats
 let
+    moi_file_formats = ["cbf", "lp", "mof", "mps", "nl", "rew", "sdpa"]
     filename, _io = Base.Filesystem.mktemp()
 
     m, n = 5, 10
@@ -11,12 +13,14 @@ let
     problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
 
     # Haven't solved the problem yet
-    @test_throws ArgumentError write_to_file(problem, filename)
+    @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
 
-    # Make sure file is written without error
+    # Make sure files are written without error
     # Can't check correctness since we don't provide a read_to_file function
     solve!(problem, SCS.Optimizer)
-    @test write_to_file(problem, filename) |> isnothing
+    for ext in moi_file_formats
+        @test write_to_file(problem, filename * ext) |> isnothing
+    end
 end
 
 # Eric Hanson's fancy problem from issue #395
@@ -28,10 +32,10 @@ let
     problem = minimize(real(tr(x)), tr(x * [1.0 im; -im 0]) == 0, x[1, 1] == 1)
 
     # Haven't solved the problem yet
-    @test_throws ArgumentError write_to_file(problem, filename)
+    @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
 
     # Make sure file is written without error
     # Can't check correctness since we don't provide a read_to_file function
     solve!(problem, SCS.Optimizer)
-    @test write_to_file(problem, filename) |> isnothing
+    @test write_to_file(problem, filename * ".sdpa") |> isnothing
 end

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -6,8 +6,8 @@
 
     m, n = 5, 10
     x = Variable(n)
-    A = randn(m, n)
-    b = randn(m)
+    A = rand(m, n)
+    b = rand(m)
     problem::Problem{Float64} =
         minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
 
@@ -36,8 +36,8 @@ end
 
     m, n = 5, 10
     x = Variable(n)
-    A = randn(Float32, m, n)
-    b = randn(Float32, m)
+    A = rand(Float32, m, n)
+    b = rand(Float32, m)
     problem::Problem{Float32} = minimize(
         sumsquares(A * x - b),
         [0 <= x, x <= 1],
@@ -72,8 +72,8 @@ end
 
     m, n = 5, 10
     x = Variable(n)
-    A = randn(BigFloat, m, n)
-    b = randn(BigFloat, m)
+    A = rand(BigFloat, m, n)
+    b = rand(BigFloat, m)
     problem::Problem{BigFloat} = minimize(
         sumsquares(A * x - b),
         [0 <= x, x <= 1],

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -1,6 +1,36 @@
 # Tests of the write_to_file(problem, filename) interface
 
-# Simple quadratic program 
+# Simple quadratic program
+@testset "Simple quadratic program (Float64 eltype)" begin
+    filename, _io = Base.Filesystem.mktemp()
+
+    m, n = 5, 10
+    x = Variable(n)
+    A = randn(m, n)
+    b = randn(m)
+    problem::Problem{Float64} =
+        minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
+
+    # Haven't solved the problem yet, should get an ArgumentError
+    @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
+
+    solve!(problem, SCS.Optimizer)
+
+    # Format lists pulled from source code of MOI.FileFormats.Model
+    # These are the formats that are compatible with this problem
+    format_ok = [".cbf", ".mof.json", ".dat-s", ".sdpa"]
+    for ext in format_ok
+        @test write_to_file(problem, filename * ext) |> isnothing
+    end
+
+    # These formats are not compatible; the specific exception varies
+    format_bad = [".lp", ".mps", ".rew", ".nl"]
+    for ext in format_bad
+        @test_throws Exception write_to_file(problem, filename * ext)
+    end
+end
+
+# Simple quadratic program, different eltype
 @testset "Simple quadratic program (Float32 eltype)" begin
     filename, _io = Base.Filesystem.mktemp()
 

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -1,9 +1,7 @@
 # Tests of the write_to_file(problem, filename) interface
 
 # Simple quadratic program
-# Can be written in any of the formats
-let
-    moi_file_formats = ["cbf", "lp", "mof", "mps", "nl", "rew", "sdpa"]
+@testset "Simply quadratic program" begin
     filename, _io = Base.Filesystem.mktemp()
 
     m, n = 5, 10
@@ -12,30 +10,48 @@ let
     b = randn(m)
     problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
 
-    # Haven't solved the problem yet
+    # Haven't solved the problem yet, should get an ArgumentError
     @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
 
-    # Make sure files are written without error
-    # Can't check correctness since we don't provide a read_to_file function
     solve!(problem, SCS.Optimizer)
-    for ext in moi_file_formats
+
+    # Format lists pulled from source code of MOI.FileFormats.Model
+    # These are the formats that are compatible with this problem
+    format_ok = [".cbf", ".mof.json", ".dat-s", ".sdpa"]
+    for ext in format_ok
         @test write_to_file(problem, filename * ext) |> isnothing
+    end
+
+    # These formats are not compatible; the specific exception varies
+    format_bad = [".lp", ".mps", ".rew", ".nl"]
+    for ext in format_bad
+        @test_throws Exception write_to_file(problem, filename * ext)
     end
 end
 
 # Eric Hanson's fancy problem from issue #395
 # https://github.com/jump-dev/Convex.jl/issues/395
-let
+@testset "Fancy SDP" begin
     filename, _io = Base.Filesystem.mktemp()
 
     x = HermitianSemidefinite(2)
     problem = minimize(real(tr(x)), tr(x * [1.0 im; -im 0]) == 0, x[1, 1] == 1)
 
-    # Haven't solved the problem yet
+    # Haven't solved the problem yet, should get an ArgumentError
     @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
 
-    # Make sure file is written without error
-    # Can't check correctness since we don't provide a read_to_file function
     solve!(problem, SCS.Optimizer)
-    @test write_to_file(problem, filename * ".sdpa") |> isnothing
+
+    # Format lists pulled from source code of MOI.FileFormats.Model
+    # These are the formats that are compatible with this problem
+    format_ok = [".cbf", ".mof.json", ".dat-s", ".sdpa"]
+    for ext in format_ok
+        @test write_to_file(problem, filename * ext) |> isnothing
+    end
+
+    # These formats are not compatible; the specific exception varies
+    format_bad = [".lp", ".mps", ".rew", ".nl"]
+    for ext in format_bad
+        @test_throws Exception write_to_file(problem, filename * ext)
+    end
 end

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -6,8 +6,8 @@
 
     m, n = 5, 10
     x = Variable(n)
-    A = randn(m, n)
-    b = randn(m)
+    A = randn(Float32, m, n)
+    b = randn(Float32, m)
     problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
 
     # Haven't solved the problem yet, should get an ArgumentError

--- a/test/write_to_file.jl
+++ b/test/write_to_file.jl
@@ -1,6 +1,6 @@
 # Tests of the write_to_file(problem, filename) interface
 
-# Simple quadratic program
+# Simple quadratic program 
 @testset "Simple quadratic program (Float32 eltype)" begin
     filename, _io = Base.Filesystem.mktemp()
 
@@ -8,12 +8,19 @@
     x = Variable(n)
     A = randn(Float32, m, n)
     b = randn(Float32, m)
-    problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
+    problem::Problem{Float32} = minimize(
+        sumsquares(A * x - b),
+        [0 <= x, x <= 1],
+        numeric_type = Float32,
+    )
 
     # Haven't solved the problem yet, should get an ArgumentError
     @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
 
-    solve!(problem, SCS.Optimizer)
+    # Throws an error because SCS doesn't support this eltype
+    # (Hypatia.jl gives a similar error)
+    @test_broken solve!(problem, SCS.Optimizer)
+    return
 
     # Format lists pulled from source code of MOI.FileFormats.Model
     # These are the formats that are compatible with this problem
@@ -29,7 +36,7 @@
     end
 end
 
-# Simple quadratic program
+# Same quadratic program, different eltype
 @testset "Simple quadratic program (BigFloat eltype)" begin
     filename, _io = Base.Filesystem.mktemp()
 
@@ -37,12 +44,19 @@ end
     x = Variable(n)
     A = randn(BigFloat, m, n)
     b = randn(BigFloat, m)
-    problem = minimize(sumsquares(A * x - b), [0 <= x, x <= 1])
+    problem::Problem{BigFloat} = minimize(
+        sumsquares(A * x - b),
+        [0 <= x, x <= 1],
+        numeric_type = BigFloat,
+    )
 
     # Haven't solved the problem yet, should get an ArgumentError
     @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")
 
-    solve!(problem, SCS.Optimizer)
+    # Throws an error because SCS doesn't support this eltype
+    # (Hypatia.jl gives a similar error)
+    @test_broken solve!(problem, SCS.Optimizer)
+    return
 
     # Format lists pulled from source code of MOI.FileFormats.Model
     # These are the formats that are compatible with this problem
@@ -64,7 +78,8 @@ end
     filename, _io = Base.Filesystem.mktemp()
 
     x = HermitianSemidefinite(2)
-    problem = minimize(real(tr(x)), tr(x * [1.0 im; -im 0]) == 0, x[1, 1] == 1)
+    problem::Problem{Float64} =
+        minimize(real(tr(x)), tr(x * [1.0 im; -im 0]) == 0, x[1, 1] == 1)
 
     # Haven't solved the problem yet, should get an ArgumentError
     @test_throws ArgumentError write_to_file(problem, filename * ".sdpa")


### PR DESCRIPTION
This PR adds a `write_to_file(problem, filename)` API. It's basically just a copy-paste job of what @ericphanson demonstrated in the enhancement request: https://github.com/jump-dev/Convex.jl/issues/395

Example:

```julia
using Convex, SCS

let
    x = Variable(8)
    problem = minimize(sumsquares(randn(5, 8) * x - randn(5)), [0 <= x, x <= 1])

    solve!(problem, SCS.Optimizer)
    write_to_file(problem, "file.sdpa")
end
```

`file.sdpa`:

```text
11
7
-1 -8 -8 -1 -1 5 2
0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0
0 1 1 1 -1.0
...
```

The function throws an informative error if the user has not yet called `solve!`.

I included a **docstring** and some **unit tests** (`test/write_to_file.jl`).

Note that there is no corresponding `read_from_file()` function, because (if I am not mistaken) boiling a convex problem down into the MOI format via Convex.jl's DCP rules is a nonreversible operation.