### PR TITLE
Add `relative_entropy` to operations documentation

### DIFF
--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -101,7 +101,7 @@ exponential cone solver (SCS).
 | `log(x)`              | $\log(x)$                         | concave | increasing    | IC: $x>0$      |
 | `entropy(x)`          | $\sum_{ij} -x_{ij} \log(x_{ij})$  | concave | not monotonic | IC: $x>0$      |
 | `logisticloss(x)`     | $\log(1 + \exp(x_i))$             | convex  | increasing    | none           |
-| `relative_entropy(x)` | $\sum_i x_i \log(x_i / y_i)$      | convex  | not monotonic | IC: $x>0, y>0$ |
+| `relative_entropy(x, y)` | $\sum_i x_i \log(x_i / y_i)$      | convex  | not monotonic | IC: $x>0, y>0$ |
 
 Semidefinite Program Representable Functions
 --------------------------------------------

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -94,13 +94,14 @@ Exponential Cone Representable Functions
 An optimization problem using these functions can be solved by any
 exponential cone solver (SCS).
 
-| operation         | description                       | vexity  | slope         | notes     |
-|-------------------|-----------------------------------|---------|---------------|-----------|
-| `logsumexp(x)`    | $\log(\sum_i \exp(x_i))$          | convex  | increasing    | none      |
-| `exp(x)`          | $\exp(x)$                         | convex  | increasing    | none      |
-| `log(x)`          | $\log(x)$                         | concave | increasing    | IC: $x>0$ |
-| `entropy(x)`      | $\sum_{ij} -x_{ij} \log (x_{ij})$ | concave | not monotonic | IC: $x>0$ |
-| `logisticloss(x)` | $\log(1 + \exp(x_i))$             | convex  | increasing    | none      |
+| operation             | description                       | vexity  | slope         | notes          |
+|-----------------------|-----------------------------------|---------|---------------|----------------|
+| `logsumexp(x)`        | $\log(\sum_i \exp(x_i))$          | convex  | increasing    | none           |
+| `exp(x)`              | $\exp(x)$                         | convex  | increasing    | none           |
+| `log(x)`              | $\log(x)$                         | concave | increasing    | IC: $x>0$      |
+| `entropy(x)`          | $\sum_{ij} -x_{ij} \log(x_{ij})$  | concave | not monotonic | IC: $x>0$      |
+| `logisticloss(x)`     | $\log(1 + \exp(x_i))$             | convex  | increasing    | none           |
+| `relative_entropy(x)` | $\sum_i x_i \log(x_i / y_i)$      | convex  | not monotonic | IC: $x>0, y>0$ |
 
 Semidefinite Program Representable Functions
 --------------------------------------------


### PR DESCRIPTION
This PR adds a line to `docs/src/operations.md` to cover the `relative_entropy(x, y)` (KL divergence) function, as requested in this issue: https://github.com/jump-dev/Convex.jl/issues/499

----

- Unfortunately, I was unable to build the docs locally to double-check for syntax errors: 

```text
ERROR: LoadError: `makedocs` encountered errors (:cross_references, :example_block). Terminating build before rendering.
```

- I notice that `entropy(x)` and `relative_entropy(x)` have opposite signs, despite the former being a special case of the latter. Any interest in a PR fixing this? Which one should flip? This would be a breaking change in either case.