### PR TITLE
Less piracy of `hcat` and `vcat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Convex"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v0.15.4 (October 24, 2023)
+
+* Convex's piracy of `hcat` and `vcat` was made less severe, allowing precompilation of Convex.jl on Julia 1.10.
+
 ## v0.15.3 (February 11, 2023)
 
  * Add support for LDLFactorizations v0.10 [#496](https://github.com/jump-dev/Convex.jl/pull/496).


### PR DESCRIPTION
Fixes #512 
Closes #513 
Closes #514 

Non-breaking alternative to #513. Since this isn't breaking, we probably should do it even if we want something like that. 