### PR TITLE
Refactor imports to explicitly overload methods

### DIFF
--- a/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
+++ b/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
@@ -40,7 +40,7 @@ struct AntidiagAtom <: AbstractExpr
     end
 end
 
-function sign(x::AntidiagAtom)
+function Base.sign(x::AntidiagAtom)
     return sign(x.children[1])
 end
 

--- a/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
+++ b/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
@@ -40,7 +40,7 @@ struct AntidiagAtom <: AbstractExpr
     end
 end
 
-function Base.sign(x::AntidiagAtom)
+function sign(x::AntidiagAtom)
     return sign(x.children[1])
 end
 

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -126,7 +126,7 @@ mutable struct ProbabilityVector <: Convex.AbstractVariable
 end
 
 Convex.get_constraints(p::ProbabilityVector) = [ sum(p) == 1 ]
-Base.sign(::ProbabilityVector) = Convex.Positive()
+Convex.sign(::ProbabilityVector) = Convex.Positive()
 Convex.vartype(::ProbabilityVector) = Convex.ContVar
 
 (p::ProbabilityVector)(x) = dot(p, x)

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -126,7 +126,7 @@ mutable struct ProbabilityVector <: Convex.AbstractVariable
 end
 
 Convex.get_constraints(p::ProbabilityVector) = [ sum(p) == 1 ]
-Convex.sign(::ProbabilityVector) = Convex.Positive()
+Base.sign(::ProbabilityVector) = Convex.Positive()
 Convex.vartype(::ProbabilityVector) = Convex.ContVar
 
 (p::ProbabilityVector)(x) = dot(p, x)

--- a/src/Context.jl
+++ b/src/Context.jl
@@ -3,7 +3,7 @@ mutable struct Context{T,M}
     model::M
 
     # Used for populating variable values after solving
-    var_id_to_moi_indices::OrderedDict{
+    var_id_to_moi_indices::OrderedCollections.OrderedDict{
         UInt64,
         Union{
             Vector{MOI.VariableIndex},
@@ -11,7 +11,7 @@ mutable struct Context{T,M}
         },
     }
     # `id_hash` -> `AbstractVariable`
-    id_to_variables::OrderedDict{UInt64,Any}
+    id_to_variables::OrderedCollections.OrderedDict{UInt64,Any}
 
     # Used for populating constraint duals
     constr_to_moi_inds::IdDict{Any,Any}
@@ -27,8 +27,8 @@ function Context{T}(optimizer_factory) where {T}
     model = MOI.instantiate(optimizer_factory, with_bridge_type = T)
     return Context{T,typeof(model)}(
         model,
-        OrderedDict{UInt64,Vector{MOI.VariableIndex}}(),
-        OrderedDict{UInt64,Any}(),
+        OrderedCollections.OrderedDict{UInt64,Vector{MOI.VariableIndex}}(),
+        OrderedCollections.OrderedDict{UInt64,Any}(),
         IdDict{Any,Any}(),
         false,
         IdDict{Any,Any}(),

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -64,8 +64,10 @@ for k in (
     :norm2,
     :tr,
 )
-    @eval $k = LinearAlgebra.$k
-    @eval export $k
+    @eval begin
+        using LinearAlgebra: $k
+        export $k
+    end
 end
 
 # Constraints

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -1,42 +1,61 @@
-__precompile__()
-
 module Convex
-using OrderedCollections: OrderedDict
-using LinearAlgebra
-using SparseArrays
-using LDLFactorizations
-using AbstractTrees: AbstractTrees, children
-# using DataStructures
 
+import AbstractTrees
+import LDLFactorizations
+import LinearAlgebra
 import MathOptInterface as MOI
+import OrderedCollections
+import SparseArrays
 
 # Functions
 export conv,
-    dotsort, entropy, exp, geomean, hinge_loss, huber, inner_product, invpos
-export log_perspective,
+    dotsort,
+    entropy,
+    exp,
+    geomean,
+    hinge_loss,
+    huber,
+    inner_product,
+    invpos,
+    log_perspective,
     logisticloss,
     logsumexp,
     matrixfrac,
     neg,
-    norm2,
+    # norm2,
     norm_1,
     norm_inf,
-    nuclearnorm
-export partialtrace,
-    partialtranspose, pos, qol_elementwise, quadform, quadoverlin, rationalnorm
-export relative_entropy,
-    sigmamax, square, sumlargest, sumlargesteigs, sumsmallest, sumsquares
-export GeomMeanHypoCone,
+    nuclearnorm,
+    partialtrace,
+    partialtranspose,
+    pos,
+    qol_elementwise,
+    quadform,
+    quadoverlin,
+    rationalnorm,
+    relative_entropy,
+    sigmamax,
+    square,
+    sumlargest,
+    sumlargesteigs,
+    sumsmallest,
+    sumsquares,
+    GeomMeanHypoCone,
     GeomMeanEpiCone,
     RelativeEntropyEpiCone,
     quantum_relative_entropy,
-    quantum_entropy
-export trace_logm, trace_mpower, lieb_ando
+    quantum_entropy,
+    trace_logm,
+    trace_mpower,
+    lieb_ando
 
 export DCPViolationError
 
 # rexports from LinearAlgebra
-export diag, diagm, Diagonal, dot, eigmax, eigmin, kron, logdet, norm, tr
+for k in (:diag, :diagm, :Diagonal, :dot, :eigmax, :eigmin, :logdet, :norm, :norm2, :tr)
+    @eval $k = LinearAlgebra.$k
+    @eval export $k
+end
 
 # Constraints
 export Constraint
@@ -47,7 +66,7 @@ export Constraint # useful for making abstractly-typed vectors via `Constraint[]
 # Variables
 export constant, ComplexVariable, HermitianSemidefinite, Semidefinite, Variable
 export curvature,
-    evaluate, fix!, free!, monotonicity, sign, vexity, problem_vexity
+    evaluate, fix!, free!, monotonicity, vexity, problem_vexity
 export BinVar, IntVar, ContVar, vartype, vartype!
 export get_constraints, add_constraint!, set_value!, evaluate
 
@@ -149,14 +168,14 @@ end
 # const SPARSE_MATRIX{T} = GBMatrix{T,T}
 # spzeros(T, d) = GBVector{T,T}(d)
 # spzeros(T, n, m) = GBMatrix{T,T}(n, m)
-# spidentity(T, d) = GBMatrix{T,T}(Diagonal(ones(T, d)))
+# spidentity(T, d) = GBMatrix{T,T}(LinearAlgebra.Diagonal(ones(T, d)))
 # create_sparse(T, args...) = GBMatrix{T,T}(args...)
 
 const SPARSE_VECTOR{T} = Vector{T}
-const SPARSE_MATRIX{T} = SparseMatrixCSC{T,Int}
+const SPARSE_MATRIX{T} = SparseArrays.SparseMatrixCSC{T,Int}
 spzeros(T, d) = zeros(T, d)
 spzeros(T, n, m) = SparseArrays.spzeros(T, n, m)
-spidentity(T, d) = sparse(one(T) * I, d, d)
+spidentity(T, d) = SparseArrays.sparse(one(T) * LinearAlgebra.I, d, d)
 function create_sparse(::Type{T}, args...) where {T}
     local result::SPARSE_MATRIX{T}
     result = SparseArrays.sparse(args...)

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -70,7 +70,7 @@ export conv,
     IntVar,
     ContVar,
     vartype,
-    vartype!
+    vartype!,
     get_constraints,
     add_constraint!,
     set_value!,

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -7,7 +7,6 @@ import MathOptInterface as MOI
 import OrderedCollections
 import SparseArrays
 
-# Functions
 export conv,
     dotsort,
     entropy,
@@ -22,7 +21,6 @@ export conv,
     logsumexp,
     matrixfrac,
     neg,
-    # norm2,
     norm_1,
     norm_inf,
     nuclearnorm,
@@ -47,9 +45,50 @@ export conv,
     quantum_entropy,
     trace_logm,
     trace_mpower,
-    lieb_ando
-
-export DCPViolationError
+    lieb_ando,
+    # Constraints
+    Constraint,
+    isposdef,
+    ⪰,
+    ⪯,
+    socp,
+    Constraint, # useful for making abstractly-typed vectors via `Constraint[]`
+    # Variables
+    constant,
+    ComplexVariable,
+    HermitianSemidefinite,
+    Semidefinite,
+    Variable,
+    curvature,
+    evaluate,
+    fix!,
+    free!,
+    monotonicity,
+    vexity,
+    problem_vexity,
+    BinVar,
+    IntVar,
+    ContVar,
+    vartype,
+    vartype!
+    get_constraints,
+    add_constraint!,
+    set_value!,
+    evaluate,
+    # Signs
+    Positive,
+    Negative,
+    ComplexSign,
+    NoSign,
+    # Problems
+    add_constraints!,
+    maximize,
+    minimize,
+    Problem,
+    satisfy,
+    solve!,
+    write_to_file,
+    DCPViolationError
 
 # Imports and exports as needed to maintain backwards compatibility
 for k in (
@@ -71,25 +110,6 @@ for k in (
 end
 using AbstractTrees: children
 using Base: sign
-
-# Constraints
-export Constraint
-export isposdef, ⪰, ⪯ # PSD constraints
-export socp
-export Constraint # useful for making abstractly-typed vectors via `Constraint[]`
-
-# Variables
-export constant, ComplexVariable, HermitianSemidefinite, Semidefinite, Variable
-export curvature, evaluate, fix!, free!, monotonicity, vexity, problem_vexity
-export BinVar, IntVar, ContVar, vartype, vartype!
-export get_constraints, add_constraint!, set_value!, evaluate
-
-# Signs
-export Positive, Negative, ComplexSign, NoSign
-
-# Problems
-export add_constraints!, maximize, minimize, Problem, satisfy, solve!
-export write_to_file
 
 # Module level globals
 

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -51,7 +51,7 @@ export conv,
 
 export DCPViolationError
 
-# rexports from LinearAlgebra
+# Imports and exports as needed to maintain backwards compatibility
 for k in (
     :diag,
     :diagm,
@@ -69,6 +69,8 @@ for k in (
         export $k
     end
 end
+using AbstractTrees: children
+using Base: sign
 
 # Constraints
 export Constraint

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -52,7 +52,18 @@ export conv,
 export DCPViolationError
 
 # rexports from LinearAlgebra
-for k in (:diag, :diagm, :Diagonal, :dot, :eigmax, :eigmin, :logdet, :norm, :norm2, :tr)
+for k in (
+    :diag,
+    :diagm,
+    :Diagonal,
+    :dot,
+    :eigmax,
+    :eigmin,
+    :logdet,
+    :norm,
+    :norm2,
+    :tr,
+)
     @eval $k = LinearAlgebra.$k
     @eval export $k
 end
@@ -65,8 +76,7 @@ export Constraint # useful for making abstractly-typed vectors via `Constraint[]
 
 # Variables
 export constant, ComplexVariable, HermitianSemidefinite, Semidefinite, Variable
-export curvature,
-    evaluate, fix!, free!, monotonicity, vexity, problem_vexity
+export curvature, evaluate, fix!, free!, monotonicity, vexity, problem_vexity
 export BinVar, IntVar, ContVar, vartype, vartype!
 export get_constraints, add_constraint!, set_value!, evaluate
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,12 +1,12 @@
 struct Optimizer{T,M} <: MOI.AbstractOptimizer
     context::Context{T,M}
-    moi_to_convex::OrderedDict{MOI.VariableIndex,UInt64}
+    moi_to_convex::OrderedCollections.OrderedDict{MOI.VariableIndex,UInt64}
     convex_to_moi::Dict{UInt64,Vector{MOI.VariableIndex}}
     constraint_map::Vector{MOI.ConstraintIndex}
     function Optimizer(context::Context{T,M}) where {T,M}
         return new{T,M}(
             context,
-            OrderedDict{MOI.VariableIndex,UInt64}(),
+            OrderedCollections.OrderedDict{MOI.VariableIndex,UInt64}(),
             Dict{UInt64,MOI.VariableIndex}(),
             MOI.ConstraintIndex[],
         )

--- a/src/VectorAffineFunctionAsMatrix.jl
+++ b/src/VectorAffineFunctionAsMatrix.jl
@@ -23,7 +23,7 @@ end
 
 # convert to a usual VAF
 function to_vaf(vaf_as_matrix::VectorAffineFunctionAsMatrix{T}) where {T}
-    I, J, V = findnz(vaf_as_matrix.aff.matrix)
+    I, J, V = SparseArrays.findnz(vaf_as_matrix.aff.matrix)
     vats = Vector{MOI.VectorAffineTerm{T}}(undef, length(I))
     for (idx, n) in enumerate(eachindex(I, J, V))
         i = I[n]

--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -19,7 +19,7 @@ mutable struct NegateAtom <: AbstractExpr
 end
 head(io::IO, ::NegateAtom) = print(io, "-")
 
-function sign(x::NegateAtom)
+function Base.sign(x::NegateAtom)
     return -sign(x.children[1])
 end
 
@@ -35,11 +35,11 @@ function evaluate(x::NegateAtom)
     return -evaluate(x.children[1])
 end
 
--(x::AbstractExpr) = NegateAtom(x)
--(x::Union{Constant,ComplexConstant}) = constant(-evaluate(x))
+Base.:-(x::AbstractExpr) = NegateAtom(x)
+Base.:-(x::Union{Constant,ComplexConstant}) = constant(-evaluate(x))
 
 function new_conic_form!(context::Context{T}, A::NegateAtom) where {T}
-    subobj = conic_form!(context, only(children(A)))
+    subobj = conic_form!(context, only(AbstractTrees.children(A)))
     if subobj isa Value
         return -subobj
     else
@@ -93,7 +93,7 @@ end
 
 head(io::IO, ::AdditionAtom) = print(io, "+")
 
-function sign(x::AdditionAtom)
+function Base.sign(x::AdditionAtom)
     return sum(Sign[sign(child) for child in x.children])
     # Creating an array of type Sign and adding all the sign of xhildren of x so if anyone is complex the resultant sign would be complex.
 end
@@ -117,14 +117,14 @@ function new_conic_form!(context::Context{T}, x::AdditionAtom) where {T}
         +,
         T,
         sign(x),
-        (conic_form!(context, c) for c in children(x))...,
+        (conic_form!(context, c) for c in AbstractTrees.children(x))...,
     )
     return obj
 end
 
-+(x::AbstractExpr, y::AbstractExpr) = AdditionAtom(x, y)
-+(x::Value, y::AbstractExpr) = AdditionAtom(constant(x), y)
-+(x::AbstractExpr, y::Value) = AdditionAtom(x, constant(y))
--(x::AbstractExpr, y::AbstractExpr) = x + (-y)
--(x::Value, y::AbstractExpr) = constant(x) + (-y)
--(x::AbstractExpr, y::Value) = x + constant(-y)
+Base.:+(x::AbstractExpr, y::AbstractExpr) = AdditionAtom(x, y)
+Base.:+(x::Value, y::AbstractExpr) = AdditionAtom(constant(x), y)
+Base.:+(x::AbstractExpr, y::Value) = AdditionAtom(x, constant(y))
+Base.:-(x::AbstractExpr, y::AbstractExpr) = x + (-y)
+Base.:-(x::Value, y::AbstractExpr) = constant(x) + (-y)
+Base.:-(x::AbstractExpr, y::Value) = x + constant(-y)

--- a/src/atoms/affine/conjugate.jl
+++ b/src/atoms/affine/conjugate.jl
@@ -9,7 +9,7 @@ mutable struct ConjugateAtom <: AbstractExpr
 end
 head(io::IO, ::ConjugateAtom) = print(io, "conj")
 
-function sign(x::ConjugateAtom)
+function Base.sign(x::ConjugateAtom)
     return sign(x.children[1])
 end
 
@@ -26,7 +26,7 @@ function evaluate(x::ConjugateAtom)
 end
 
 function new_conic_form!(context::Context{T}, x::ConjugateAtom) where {T}
-    objective = conic_form!(context, only(children(x)))
+    objective = conic_form!(context, only(AbstractTrees.children(x)))
     return operate(conj, T, sign(x), objective)
 end
 

--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -31,7 +31,7 @@ head(io::IO, ::DiagAtom) = print(io, "diag")
 
 ## Type Definition Ends
 
-function sign(x::DiagAtom)
+function Base.sign(x::DiagAtom)
     return sign(x.children[1])
 end
 
@@ -47,7 +47,7 @@ function curvature(x::DiagAtom)
 end
 
 function evaluate(x::DiagAtom)
-    return diag(evaluate(x.children[1]), x.k)
+    return LinearAlgebra.diag(evaluate(x.children[1]), x.k)
 end
 
 ## API begins
@@ -84,7 +84,7 @@ function new_conic_form!(context::Context{T}, x::DiagAtom) where {T}
         start_index += num_rows + 1
     end
 
-    child_obj = conic_form!(context, only(children(x)))
+    child_obj = conic_form!(context, only(AbstractTrees.children(x)))
     obj = operate(add_operation, T, sign(x), select_diag, child_obj)
     return obj
 end

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -5,8 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import LinearAlgebra.diagm, LinearAlgebra.Diagonal
-
 mutable struct DiagMatrixAtom <: AbstractExpr
     children::Tuple{AbstractExpr}
     size::Tuple{Int,Int}
@@ -33,7 +31,7 @@ end
 
 head(io::IO, ::DiagMatrixAtom) = print(io, "diagm")
 
-function sign(x::DiagMatrixAtom)
+function Base.sign(x::DiagMatrixAtom)
     return sign(x.children[1])
 end
 
@@ -49,18 +47,18 @@ function curvature(x::DiagMatrixAtom)
 end
 
 function evaluate(x::DiagMatrixAtom)
-    return Diagonal(vec(evaluate(x.children[1])))
+    return LinearAlgebra.Diagonal(vec(evaluate(x.children[1])))
 end
 
-function diagm((d, x)::Pair{<:Integer,<:AbstractExpr})
+function LinearAlgebra.diagm((d, x)::Pair{<:Integer,<:AbstractExpr})
     d == 0 || throw(ArgumentError("only the main diagonal is supported"))
     return DiagMatrixAtom(x)
 end
-Diagonal(x::AbstractExpr) = DiagMatrixAtom(x)
-diagm(x::AbstractExpr) = DiagMatrixAtom(x)
+LinearAlgebra.Diagonal(x::AbstractExpr) = DiagMatrixAtom(x)
+LinearAlgebra.diagm(x::AbstractExpr) = DiagMatrixAtom(x)
 
 function new_conic_form!(context::Context{T}, x::DiagMatrixAtom) where {T}
-    obj = conic_form!(context, only(children(x)))
+    obj = conic_form!(context, only(AbstractTrees.children(x)))
 
     sz = x.size[1]
     I = collect(1:sz+1:sz*sz)

--- a/src/atoms/affine/dot.jl
+++ b/src/atoms/affine/dot.jl
@@ -1,5 +1,3 @@
-import LinearAlgebra.dot
-
 function ismatrix(x::AbstractExpr)
     return (s = size(x); length(s) == 2 && s[1] > 1 && s[2] > 1)
 end
@@ -12,6 +10,6 @@ ismatrix(::Any) = false
 asvec(x) = convert(AbstractExpr, ismatrix(x) ? vec(x) : x)
 _vecdot(x, y) = sum(broadcast(*, conj(asvec(x)), asvec(y)))
 
-dot(x::AbstractExpr, y::AbstractExpr) = _vecdot(x, y)
-dot(x::Value, y::AbstractExpr) = _vecdot(x, y)
-dot(x::AbstractExpr, y::Value) = _vecdot(x, y)
+LinearAlgebra.dot(x::AbstractExpr, y::AbstractExpr) = _vecdot(x, y)
+LinearAlgebra.dot(x::Value, y::AbstractExpr) = _vecdot(x, y)
+LinearAlgebra.dot(x::AbstractExpr, y::Value) = _vecdot(x, y)

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -92,9 +92,13 @@ function Base.getindex(
 ) where {T<:Real}
     return IndexAtom(x, rows, cols)
 end
-Base.getindex(x::AbstractExpr, inds::AbstractVector{<:Real}) = IndexAtom(x, inds)
+function Base.getindex(x::AbstractExpr, inds::AbstractVector{<:Real})
+    return IndexAtom(x, inds)
+end
 Base.getindex(x::AbstractExpr, ind::Real) = getindex(x, ind:ind)
-Base.getindex(x::AbstractExpr, row::Real, col::Real) = getindex(x, row:row, col:col)
+function Base.getindex(x::AbstractExpr, row::Real, col::Real)
+    return getindex(x, row:row, col:col)
+end
 function Base.getindex(x::AbstractExpr, row::Real, cols::AbstractVector{<:Real})
     return getindex(x, row:row, cols)
 end
@@ -115,9 +119,13 @@ function Base.getindex(x::AbstractExpr, cln_r::Colon, cln_c::Colon)
     return getindex(x, 1:rows, 1:cols)
 end
 # All rows for this column(s)
-Base.getindex(x::AbstractExpr, cln_r::Colon, col) = getindex(x, 1:size(x)[1], col)
+function Base.getindex(x::AbstractExpr, cln_r::Colon, col)
+    return getindex(x, 1:size(x)[1], col)
+end
 # All columns for this row(s)
-Base.getindex(x::AbstractExpr, row, cln_c::Colon) = getindex(x, row, 1:size(x)[2])
+function Base.getindex(x::AbstractExpr, row, cln_c::Colon)
+    return getindex(x, row, 1:size(x)[2])
+end
 
 # Cartesian Index
 Base.getindex(x::AbstractExpr, c::CartesianIndex{N}) where {N} = x[Tuple(c)...]

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -1,5 +1,3 @@
-import Base.getindex
-
 const ArrayOrNothing = Union{AbstractArray,Nothing}
 
 mutable struct IndexAtom <: AbstractExpr
@@ -30,7 +28,7 @@ head(io::IO, ::IndexAtom) = print(io, "index")
 
 ## Type definition ends here
 
-function sign(x::IndexAtom)
+function Base.sign(x::IndexAtom)
     return sign(x.children[1])
 end
 
@@ -53,7 +51,7 @@ function evaluate(x::IndexAtom)
 end
 
 function new_conic_form!(context::Context{T}, x::IndexAtom) where {T}
-    obj = conic_form!(context, only(children(x)))
+    obj = conic_form!(context, only(AbstractTrees.children(x)))
 
     m = length(x)
     n = length(x.children[1])
@@ -87,41 +85,41 @@ end
 
 ## API Definition begins
 
-function getindex(
+function Base.getindex(
     x::AbstractExpr,
     rows::AbstractVector{T},
     cols::AbstractVector{T},
 ) where {T<:Real}
     return IndexAtom(x, rows, cols)
 end
-getindex(x::AbstractExpr, inds::AbstractVector{<:Real}) = IndexAtom(x, inds)
-getindex(x::AbstractExpr, ind::Real) = getindex(x, ind:ind)
-getindex(x::AbstractExpr, row::Real, col::Real) = getindex(x, row:row, col:col)
-function getindex(x::AbstractExpr, row::Real, cols::AbstractVector{<:Real})
+Base.getindex(x::AbstractExpr, inds::AbstractVector{<:Real}) = IndexAtom(x, inds)
+Base.getindex(x::AbstractExpr, ind::Real) = getindex(x, ind:ind)
+Base.getindex(x::AbstractExpr, row::Real, col::Real) = getindex(x, row:row, col:col)
+function Base.getindex(x::AbstractExpr, row::Real, cols::AbstractVector{<:Real})
     return getindex(x, row:row, cols)
 end
-function getindex(x::AbstractExpr, rows::AbstractVector{<:Real}, col::Real)
+function Base.getindex(x::AbstractExpr, rows::AbstractVector{<:Real}, col::Real)
     return getindex(x, rows, col:col)
 end
 # XXX todo: speed test; there are lots of possible solutions for this
-function getindex(x::AbstractExpr, I::AbstractMatrix{Bool})
+function Base.getindex(x::AbstractExpr, I::AbstractMatrix{Bool})
     return [xi for (xi, ii) in zip(x, I) if ii]
 end
-function getindex(x::AbstractExpr, I::AbstractVector{Bool})
+function Base.getindex(x::AbstractExpr, I::AbstractVector{Bool})
     return [xi for (xi, ii) in zip(x, I) if ii]
 end
 # Colon methods
 # All rows and columns
-function getindex(x::AbstractExpr, cln_r::Colon, cln_c::Colon)
+function Base.getindex(x::AbstractExpr, cln_r::Colon, cln_c::Colon)
     rows, cols = size(x)
     return getindex(x, 1:rows, 1:cols)
 end
 # All rows for this column(s)
-getindex(x::AbstractExpr, cln_r::Colon, col) = getindex(x, 1:size(x)[1], col)
+Base.getindex(x::AbstractExpr, cln_r::Colon, col) = getindex(x, 1:size(x)[1], col)
 # All columns for this row(s)
-getindex(x::AbstractExpr, row, cln_c::Colon) = getindex(x, row, 1:size(x)[2])
+Base.getindex(x::AbstractExpr, row, cln_c::Colon) = getindex(x, row, 1:size(x)[2])
 
 # Cartesian Index
-getindex(x::AbstractExpr, c::CartesianIndex{N}) where {N} = x[Tuple(c)...]
+Base.getindex(x::AbstractExpr, c::CartesianIndex{N}) where {N} = x[Tuple(c)...]
 
 ## API Definition ends

--- a/src/atoms/affine/inner_product.jl
+++ b/src/atoms/affine/inner_product.jl
@@ -1,6 +1,6 @@
 function inner_product(x::AbstractExpr, y::AbstractExpr)
     if x.size == y.size && x.size[1] == x.size[2]
-        return real(tr(x' * y))
+        return real(LinearAlgebra.tr(x' * y))
     else
         error("Arguments must be square matrix of same dimension")
     end

--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -1,4 +1,4 @@
-function LinearAlgebra.kron(a::Value, b::AbstractExpr)
+function Base.kron(a::Value, b::AbstractExpr)
     rows = AbstractExpr[]
     for i in 1:size(a)[1]
         row = AbstractExpr[]
@@ -14,7 +14,7 @@ function LinearAlgebra.kron(a::Value, b::AbstractExpr)
     return foldl(vcat, rows)
 end
 
-function LinearAlgebra.kron(a::AbstractExpr, b::Value)
+function Base.kron(a::AbstractExpr, b::Value)
     rows = AbstractExpr[]
     for i in 1:size(a)[1]
         row = AbstractExpr[]

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -6,8 +6,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import Base.Broadcast.broadcasted
-
 ### Scalar and matrix multiplication
 
 mutable struct MultiplyAtom <: AbstractExpr
@@ -33,7 +31,7 @@ end
 
 head(io::IO, ::MultiplyAtom) = print(io, "*")
 
-function sign(x::MultiplyAtom)
+function Base.sign(x::MultiplyAtom)
     return sign(x.children[1]) * sign(x.children[2])
 end
 
@@ -157,16 +155,16 @@ function new_conic_form!(context::Context{T}, x::MultiplyAtom) where {T}
     end
 end
 
-function *(x::AbstractExpr, y::AbstractExpr)
+function Base.:*(x::AbstractExpr, y::AbstractExpr)
     if isequal(x, y) && x.size == (1, 1)
         return square(x)
     end
     return MultiplyAtom(x, y)
 end
 
-*(x::Value, y::AbstractExpr) = MultiplyAtom(constant(x), y)
-*(x::AbstractExpr, y::Value) = MultiplyAtom(x, constant(y))
-/(x::AbstractExpr, y::Value) = MultiplyAtom(x, constant(1 ./ y))
+Base.:*(x::Value, y::AbstractExpr) = MultiplyAtom(constant(x), y)
+Base.:*(x::AbstractExpr, y::Value) = MultiplyAtom(x, constant(y))
+Base.:/(x::AbstractExpr, y::Value) = MultiplyAtom(x, constant(1 ./ y))
 
 # # ambiguity
 # function Base.:(*)(
@@ -223,25 +221,25 @@ function dotmultiply(x, y)
     elseif size(var, 2) < size(coeff, 2)
         var = var * ones(1, size(coeff, 1))
     end
-    const_multiplier = Diagonal(vec(coeff))
+    const_multiplier = LinearAlgebra.Diagonal(vec(coeff))
     return reshape(const_multiplier * vec(var), size(var)...)
 end
 
 # if neither is a constant it's not DCP, but might be nice to support anyway for eg MultiConvex
-function broadcasted(::typeof(*), x::AbstractExpr, y::AbstractExpr)
+function Base.Broadcast.broadcasted(::typeof(*), x::AbstractExpr, y::AbstractExpr)
     if isequal(x, y)
         return square(x)
     else
         return dotmultiply(x, y)
     end
 end
-function broadcasted(::typeof(*), x::Value, y::AbstractExpr)
+function Base.Broadcast.broadcasted(::typeof(*), x::Value, y::AbstractExpr)
     return dotmultiply(constant(x), y)
 end
-function broadcasted(::typeof(*), x::AbstractExpr, y::Value)
+function Base.Broadcast.broadcasted(::typeof(*), x::AbstractExpr, y::Value)
     return dotmultiply(constant(y), x)
 end
-function broadcasted(::typeof(/), x::AbstractExpr, y::Value)
+function Base.Broadcast.broadcasted(::typeof(/), x::AbstractExpr, y::Value)
     return dotmultiply(constant(1 ./ y), x)
 end
 # x ./ y and x / y for x constant, y variable is defined in second_order_cone.qol_elemwise.jl

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -226,7 +226,11 @@ function dotmultiply(x, y)
 end
 
 # if neither is a constant it's not DCP, but might be nice to support anyway for eg MultiConvex
-function Base.Broadcast.broadcasted(::typeof(*), x::AbstractExpr, y::AbstractExpr)
+function Base.Broadcast.broadcasted(
+    ::typeof(*),
+    x::AbstractExpr,
+    y::AbstractExpr,
+)
     if isequal(x, y)
         return square(x)
     else

--- a/src/atoms/affine/partialtranspose.jl
+++ b/src/atoms/affine/partialtranspose.jl
@@ -41,10 +41,10 @@ Returns a matrix `M` so that for any vector `v` of length `prod(dims)`,
 function permutedims_matrix(dims, p)
     d = prod(dims)
     n = length(dims)
-    return sparse(
+    return SparseArrays.sparse(
         reshape(
             PermutedDimsArray(
-                reshape(Matrix(I, d, d), (dims..., dims...)),
+                reshape(Matrix(LinearAlgebra.I, d, d), (dims..., dims...)),
                 (p..., (n+1:2n)...),
             ),
             (d, d),

--- a/src/atoms/affine/real_imag.jl
+++ b/src/atoms/affine/real_imag.jl
@@ -4,8 +4,6 @@
 # and expressions.
 #############################################################################
 
-import Base.real, Base.imag
-
 ### Real
 mutable struct RealAtom <: AbstractExpr
     children::Tuple{AbstractExpr}
@@ -19,7 +17,7 @@ end
 
 head(io::IO, ::RealAtom) = print(io, "real")
 
-function sign(x::RealAtom)
+function Base.sign(x::RealAtom)
     if sign(x.children[1]) == ComplexSign()
         return NoSign()
     else
@@ -40,13 +38,13 @@ function evaluate(x::RealAtom)
 end
 
 function new_conic_form!(context::Context{T}, x::RealAtom) where {T}
-    obj = conic_form!(context, only(children(x)))
+    obj = conic_form!(context, only(AbstractTrees.children(x)))
     return operate(real, T, sign(x), obj)
 end
 
-real(x::AbstractExpr) = RealAtom(x)
-real(x::ComplexConstant) = x.real_constant
-real(x::Constant) = x
+Base.real(x::AbstractExpr) = RealAtom(x)
+Base.real(x::ComplexConstant) = x.real_constant
+Base.real(x::Constant) = x
 
 ### Imaginary
 mutable struct ImaginaryAtom <: AbstractExpr
@@ -61,7 +59,7 @@ end
 
 head(io::IO, ::ImaginaryAtom) = print(io, "imag")
 
-function sign(x::ImaginaryAtom)
+function Base.sign(x::ImaginaryAtom)
     sign(x.children[1]) == ComplexSign()
     return NoSign()
 end
@@ -79,10 +77,10 @@ function evaluate(x::ImaginaryAtom)
 end
 
 function new_conic_form!(context::Context{T}, x::ImaginaryAtom) where {T}
-    obj = conic_form!(context, only(children(x)))
+    obj = conic_form!(context, only(AbstractTrees.children(x)))
     return operate(imag, T, sign(x), obj)
 end
 
-imag(x::AbstractExpr) = ImaginaryAtom(x)
-imag(x::ComplexConstant) = x.imag_constant
-imag(x::Constant) = Constant(zero(x.value))
+Base.imag(x::AbstractExpr) = ImaginaryAtom(x)
+Base.imag(x::ComplexConstant) = x.imag_constant
+Base.imag(x::Constant) = Constant(zero(x.value))

--- a/src/atoms/affine/reshape.jl
+++ b/src/atoms/affine/reshape.jl
@@ -13,7 +13,7 @@ mutable struct ReshapeAtom <: AbstractExpr
 end
 head(io::IO, ::ReshapeAtom) = print(io, "reshape")
 
-function sign(x::ReshapeAtom)
+function Base.sign(x::ReshapeAtom)
     return sign(x.children[1])
 end
 
@@ -34,7 +34,7 @@ function evaluate(x::ReshapeAtom)
 end
 
 function new_conic_form!(context::Context, A::ReshapeAtom)
-    return conic_form!(context, only(children(A)))
+    return conic_form!(context, only(AbstractTrees.children(A)))
 end
 
 Base.reshape(x::AbstractExpr, m::Int, n::Int) = ReshapeAtom(x, m, n)

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -1,4 +1,3 @@
-import Base.vcat, Base.hcat, Base.hvcat
 mutable struct HcatAtom <: AbstractExpr
     children::Tuple
     size::Tuple{Int,Int}
@@ -22,7 +21,7 @@ end
 
 head(io::IO, ::HcatAtom) = print(io, "hcat")
 
-function sign(x::HcatAtom)
+function Base.sign(x::HcatAtom)
     return sum(map(sign, x.children))
 end
 
@@ -39,7 +38,7 @@ function evaluate(x::HcatAtom)
 end
 
 function new_conic_form!(context::Context{T}, x::HcatAtom) where {T}
-    objectives = map(c -> conic_form!(context, c), children(x))
+    objectives = map(c -> conic_form!(context, c), AbstractTrees.children(x))
     # Suppose the child objectives for two children e1 (2 x 1) and e2 (2 x 2) look something like
     #  e1: x => 1 2 3
     #           4 5 6
@@ -80,15 +79,16 @@ function Base.hcat(args::AbstractExprOrValue...)
 end
 
 # TODO: implement vertical concatenation in a more efficient way
-vcat(args::AbstractExpr...) = transpose(HcatAtom(map(transpose, args)...))
-function vcat(args::AbstractExprOrValue...)
+Base.vcat(args::AbstractExpr...) = transpose(HcatAtom(map(transpose, args)...))
+
+function Base.vcat(args::AbstractExprOrValue...)
     if all(Base.Fix2(isa, Value), args)
         return Base.cat(args..., dims = Val(1))
     end
     return transpose(HcatAtom(map(transpose, args)...))
 end
 
-function hvcat(rows::Tuple{Vararg{Int}}, args::AbstractExprOrValue...)
+function Base.hvcat(rows::Tuple{Vararg{Int}}, args::AbstractExprOrValue...)
     nbr = length(rows)
     rs = Vector{Any}(undef, nbr)
     a = 1

--- a/src/atoms/affine/sum.jl
+++ b/src/atoms/affine/sum.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.sum
 
 ### Sum Atom
 mutable struct SumAtom <: AbstractExpr
@@ -19,7 +18,7 @@ end
 
 head(io::IO, ::SumAtom) = print(io, "sum")
 
-function sign(x::SumAtom)
+function Base.sign(x::SumAtom)
     return sign(x.children[1])
 end
 
@@ -39,14 +38,14 @@ function evaluate(x::SumAtom)
 end
 
 function new_conic_form!(context::Context{T}, A::SumAtom) where {T}
-    subobj = conic_form!(context, only(children(A)))
+    subobj = conic_form!(context, only(AbstractTrees.children(A)))
     obj = operate(sum, T, sign(A), subobj)
     return obj
 end
 
 # Dispatch to an internal helper function that handles the dimension argument in
 # the same manner as Base, with dims=: denoting a regular sum
-sum(x::AbstractExpr; dims = :) = _sum(x, dims)
+Base.sum(x::AbstractExpr; dims = :) = _sum(x, dims)
 
 _sum(x::AbstractExpr, ::Colon) = SumAtom(x)
 
@@ -59,5 +58,3 @@ function _sum(x::AbstractExpr, dimension::Integer)
         error("Sum not implemented for dimension $dimension")
     end
 end
-
-Base.@deprecate sum(x::AbstractExpr, dim::Int) sum(x, dims = dim)

--- a/src/atoms/affine/trace.jl
+++ b/src/atoms/affine/trace.jl
@@ -1,5 +1,3 @@
-import LinearAlgebra.tr
-
-function tr(e::AbstractExpr)
-    return sum(diag(e))
+function LinearAlgebra.tr(e::AbstractExpr)
+    return sum(LinearAlgebra.diag(e))
 end

--- a/src/atoms/exp_+_sdp_cone/logdet.jl
+++ b/src/atoms/exp_+_sdp_cone/logdet.jl
@@ -1,5 +1,3 @@
-import LinearAlgebra.logdet
-
 mutable struct LogDetAtom <: AbstractExpr
     children::Tuple{AbstractExpr}
     size::Tuple{Int,Int}
@@ -12,7 +10,7 @@ end
 
 head(io::IO, ::LogDetAtom) = print(io, "logdet")
 
-function sign(x::LogDetAtom)
+function Base.sign(x::LogDetAtom)
     return NoSign()
 end
 
@@ -25,12 +23,12 @@ function curvature(x::LogDetAtom)
 end
 
 function evaluate(x::LogDetAtom)
-    return log(det(evaluate(x.children[1])))
+    return log(LinearAlgebra.det(evaluate(x.children[1])))
 end
 
 function new_conic_form!(context::Context{T}, x::LogDetAtom) where {T}
     # the object we want the logdet of. Should be a PSD matrix, but may not be a `AbstractVariable` itself.
-    A = only(children(x))
+    A = only(AbstractTrees.children(x))
 
     # We vectorize and take the upper triangle
     v = vec_triu(A)
@@ -43,7 +41,7 @@ function new_conic_form!(context::Context{T}, x::LogDetAtom) where {T}
 
     t = conic_form!(context, Variable())
     f = operate(vcat, T, sign(x), t, SPARSE_VECTOR{T}([one(T)]), X)
-    side_dimension = size(only(children(x)), 1)
+    side_dimension = size(only(AbstractTrees.children(x)), 1)
 
     set = MOI.LogDetConeTriangle(side_dimension)
 
@@ -51,4 +49,4 @@ function new_conic_form!(context::Context{T}, x::LogDetAtom) where {T}
     return t
 end
 
-logdet(x::AbstractExpr) = LogDetAtom(x)
+LinearAlgebra.logdet(x::AbstractExpr) = LogDetAtom(x)

--- a/src/atoms/exp_cone/entropy.jl
+++ b/src/atoms/exp_cone/entropy.jl
@@ -27,7 +27,7 @@ end
 
 head(io::IO, ::EntropyAtom) = print(io, "entropy")
 
-function sign(x::EntropyAtom)
+function Base.sign(x::EntropyAtom)
     return NoSign()
 end
 

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.exp
 
 ### Exponential
 
@@ -24,7 +23,7 @@ end
 
 head(io::IO, ::ExpAtom) = print(io, "exp")
 
-function sign(x::ExpAtom)
+function Base.sign(x::ExpAtom)
     return Positive()
 end
 
@@ -40,7 +39,7 @@ function evaluate(x::ExpAtom)
     return exp.(evaluate(x.children[1]))
 end
 
-exp(x::AbstractExpr) = ExpAtom(x)
+Base.exp(x::AbstractExpr) = ExpAtom(x)
 
 function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     # exp(x) \leq z  <=>  (x,ones(),z) \in ExpCone

--- a/src/atoms/exp_cone/log.jl
+++ b/src/atoms/exp_cone/log.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.log
 
 ### Logarithm
 
@@ -23,7 +22,7 @@ mutable struct LogAtom <: AbstractExpr
 end
 head(io::IO, ::LogAtom) = print(io, "log")
 
-function sign(x::LogAtom)
+function Base.sign(x::LogAtom)
     return NoSign()
 end
 
@@ -39,7 +38,7 @@ function evaluate(x::LogAtom)
     return log.(evaluate(x.children[1]))
 end
 
-log(x::AbstractExpr) = LogAtom(x)
+Base.log(x::AbstractExpr) = LogAtom(x)
 
 function new_conic_form!(context::Context, e::LogAtom)
     # log(z) \geq x  <=>    (x,ones(),z) \in ExpCone

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -25,7 +25,7 @@ end
 
 head(io::IO, ::LogSumExpAtom) = print(io, "logsumexp")
 
-function sign(x::LogSumExpAtom)
+function Base.sign(x::LogSumExpAtom)
     return NoSign()
 end
 

--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -25,7 +25,7 @@ end
 
 head(io::IO, ::RelativeEntropyAtom) = print(io, "relative_entropy")
 
-function sign(x::RelativeEntropyAtom)
+function Base.sign(x::RelativeEntropyAtom)
     return NoSign()
 end
 

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.abs, Base.abs2
 
 ### Absolute Value
 
@@ -19,7 +18,7 @@ mutable struct AbsAtom <: AbstractExpr
 end
 head(io::IO, ::AbsAtom) = print(io, "abs")
 
-function sign(x::AbsAtom)
+function Base.sign(x::AbsAtom)
     return Positive()
 end
 
@@ -43,7 +42,7 @@ function new_conic_form!(context::Context, A::AbsAtom)
 
     if sign(x) == ComplexSign()
         for i in 1:length(vec(t))
-            add_constraint!(context, t[i] >= norm2([real(x[i]); imag(x[i])]))
+            add_constraint!(context, t[i] >= LinearAlgebra.norm2([real(x[i]); imag(x[i])]))
         end
     else
         add_constraint!(context, t >= x)
@@ -52,8 +51,8 @@ function new_conic_form!(context::Context, A::AbsAtom)
     return t_obj
 end
 
-abs(x::AbstractExpr) = AbsAtom(x)
-abs2(x::AbstractExpr) = square(abs(x))
+Base.abs(x::AbstractExpr) = AbsAtom(x)
+Base.abs2(x::AbstractExpr) = square(abs(x))
 
 ## Alternate version: no atom, just a DCPPromise:
 

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -42,7 +42,10 @@ function new_conic_form!(context::Context, A::AbsAtom)
 
     if sign(x) == ComplexSign()
         for i in 1:length(vec(t))
-            add_constraint!(context, t[i] >= LinearAlgebra.norm2([real(x[i]); imag(x[i])]))
+            add_constraint!(
+                context,
+                t[i] >= LinearAlgebra.norm2([real(x[i]); imag(x[i])]),
+            )
         end
     else
         add_constraint!(context, t >= x)

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -28,7 +28,7 @@ end
 
 head(io::IO, ::DotSortAtom) = print(io, "dotsort")
 
-function sign(x::DotSortAtom)
+function Base.sign(x::DotSortAtom)
     if all(x.w .>= 0)
         return sign(x.children[1])
     elseif all(x.w .<= 0)

--- a/src/atoms/lp_cone/max.jl
+++ b/src/atoms/lp_cone/max.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.max
 
 # TODO: This can easily be extended to work
 ### Max Atom
@@ -38,7 +37,7 @@ end
 
 head(io::IO, ::MaxAtom) = print(io, "max")
 
-function sign(x::MaxAtom)
+function Base.sign(x::MaxAtom)
     sign_one = sign(x.children[1])
     sign_two = sign(x.children[2])
     if sign_one == Positive() || sign_two == Positive()
@@ -71,8 +70,8 @@ function new_conic_form!(context::Context, x::MaxAtom)
     return conic_form!(context, p)
 end
 
-max(x::AbstractExpr, y::AbstractExpr) = MaxAtom(x, y)
-max(x::AbstractExpr, y::Value) = max(x, constant(y))
-max(x::Value, y::AbstractExpr) = max(constant(x), y)
+Base.max(x::AbstractExpr, y::AbstractExpr) = MaxAtom(x, y)
+Base.max(x::AbstractExpr, y::Value) = max(x, constant(y))
+Base.max(x::Value, y::AbstractExpr) = max(constant(x), y)
 pos(x::AbstractExpr) = max(x, Constant(0, Positive()))
 hinge_loss(x::AbstractExpr) = pos(1 - x)

--- a/src/atoms/lp_cone/maximum.jl
+++ b/src/atoms/lp_cone/maximum.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.maximum
 
 ### Maximum Atom
 mutable struct MaximumAtom <: AbstractExpr
@@ -23,7 +22,7 @@ end
 
 head(io::IO, ::MaximumAtom) = print(io, "maximum")
 
-function sign(x::MaximumAtom)
+function Base.sign(x::MaximumAtom)
     return sign(x.children[1])
 end
 
@@ -48,4 +47,4 @@ function new_conic_form!(context::Context, x::MaximumAtom)
     return conic_form!(context, t)
 end
 
-maximum(x::AbstractExpr) = MaximumAtom(x)
+Base.maximum(x::AbstractExpr) = MaximumAtom(x)

--- a/src/atoms/lp_cone/min.jl
+++ b/src/atoms/lp_cone/min.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.min
 
 # TODO: This can easily be extended to work
 ### Min Atom
@@ -38,7 +37,7 @@ end
 
 head(io::IO, ::MinAtom) = print(io, "min")
 
-function sign(x::MinAtom)
+function Base.sign(x::MinAtom)
     sign_one = sign(x.children[1])
     sign_two = sign(x.children[2])
     if sign_one == Negative() || sign_two == Negative()
@@ -71,7 +70,7 @@ function new_conic_form!(context::Context, x::MinAtom)
     return conic_form!(context, p)
 end
 
-min(x::AbstractExpr, y::AbstractExpr) = MinAtom(x, y)
-min(x::AbstractExpr, y::Value) = min(x, constant(y))
-min(x::Value, y::AbstractExpr) = min(constant(x), y)
+Base.min(x::AbstractExpr, y::AbstractExpr) = MinAtom(x, y)
+Base.min(x::AbstractExpr, y::Value) = min(x, constant(y))
+Base.min(x::Value, y::AbstractExpr) = min(constant(x), y)
 neg(x::AbstractExpr) = max(-x, Constant(0, Positive()))

--- a/src/atoms/lp_cone/minimum.jl
+++ b/src/atoms/lp_cone/minimum.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import Base.minimum
 
 ### Minimum Atom
 mutable struct MinimumAtom <: AbstractExpr
@@ -23,7 +22,7 @@ end
 
 head(io::IO, ::MinimumAtom) = print(io, "minimum")
 
-function sign(x::MinimumAtom)
+function Base.sign(x::MinimumAtom)
     return sign(x.children[1])
 end
 
@@ -39,7 +38,7 @@ function curvature(x::MinimumAtom)
 end
 
 function evaluate(x::MinimumAtom)
-    return Base.minimum(evaluate(x.children[1]))
+    return minimum(evaluate(x.children[1]))
 end
 
 function new_conic_form!(context::Context, x::MinimumAtom)
@@ -48,4 +47,4 @@ function new_conic_form!(context::Context, x::MinimumAtom)
     return conic_form!(context, t)
 end
 
-minimum(x::AbstractExpr) = MinimumAtom(x)
+Base.minimum(x::AbstractExpr) = MinimumAtom(x)

--- a/src/atoms/lp_cone/sumlargest.jl
+++ b/src/atoms/lp_cone/sumlargest.jl
@@ -30,7 +30,7 @@ end
 
 head(io::IO, ::SumLargestAtom) = print(io, "sumlargest")
 
-function sign(x::SumLargestAtom)
+function Base.sign(x::SumLargestAtom)
     return sign(x.children[1])
 end
 

--- a/src/atoms/sdp_cone/eig_min_max.jl
+++ b/src/atoms/sdp_cone/eig_min_max.jl
@@ -6,8 +6,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import LinearAlgebra: eigmin, eigmax
-
 ### Eig max
 
 mutable struct EigMaxAtom <: AbstractExpr
@@ -27,7 +25,7 @@ end
 
 head(io::IO, ::EigMaxAtom) = print(io, "eigmax")
 
-function sign(x::EigMaxAtom)
+function Base.sign(x::EigMaxAtom)
     return NoSign()
 end
 
@@ -40,10 +38,10 @@ function curvature(x::EigMaxAtom)
 end
 
 function evaluate(x::EigMaxAtom)
-    return eigmax(evaluate(x.children[1]))
+    return LinearAlgebra.eigmax(evaluate(x.children[1]))
 end
 
-eigmax(x::AbstractExpr) = EigMaxAtom(x)
+LinearAlgebra.eigmax(x::AbstractExpr) = EigMaxAtom(x)
 
 # Create the equivalent conic problem:
 #   minimize t
@@ -54,7 +52,7 @@ function new_conic_form!(context::Context{T}, x::EigMaxAtom) where {T}
     A = x.children[1]
     m, n = size(A)
     t = Variable()
-    p = minimize(t, t * Matrix(one(T) * I, n, n) - A ⪰ 0)
+    p = minimize(t, t * Matrix(one(T) * LinearAlgebra.I, n, n) - A ⪰ 0)
     return conic_form!(context, p)
 end
 
@@ -77,7 +75,7 @@ end
 
 head(io::IO, ::EigMinAtom) = print(io, "eigmin")
 
-function sign(x::EigMinAtom)
+function Base.sign(x::EigMinAtom)
     return NoSign()
 end
 
@@ -90,10 +88,10 @@ function curvature(x::EigMinAtom)
 end
 
 function evaluate(x::EigMinAtom)
-    return eigmin(evaluate(x.children[1]))
+    return LinearAlgebra.eigmin(evaluate(x.children[1]))
 end
 
-eigmin(x::AbstractExpr) = EigMinAtom(x)
+LinearAlgebra.eigmin(x::AbstractExpr) = EigMinAtom(x)
 
 # Create the equivalent conic problem:
 #   maximize t
@@ -104,6 +102,6 @@ function new_conic_form!(context::Context, x::EigMinAtom)
     A = x.children[1]
     m, n = size(A)
     t = Variable()
-    p = maximize(t, A - t * Matrix(1.0I, n, n) ⪰ 0)
+    p = maximize(t, A - t * Matrix(1.0 * LinearAlgebra.I, n, n) ⪰ 0)
     return conic_form!(context, p)
 end

--- a/src/atoms/sdp_cone/geom_mean_epicone.jl
+++ b/src/atoms/sdp_cone/geom_mean_epicone.jl
@@ -98,7 +98,7 @@ end
 
 head(io::IO, ::GeomMeanEpiConeConstraint) = print(io, "∈(GeomMeanEpiCone)")
 
-in(T, cone::GeomMeanEpiCone) = GeomMeanEpiConeConstraint(T, cone)
+Base.in(T, cone::GeomMeanEpiCone) = GeomMeanEpiConeConstraint(T, cone)
 
 function AbstractTrees.children(constraint::GeomMeanEpiConeConstraint)
     return (

--- a/src/atoms/sdp_cone/geom_mean_hypocone.jl
+++ b/src/atoms/sdp_cone/geom_mean_hypocone.jl
@@ -105,7 +105,7 @@ end
 
 head(io::IO, ::GeomMeanHypoConeConstraint) = print(io, "∈(GeomMeanHypoCone)")
 
-in(T, cone::GeomMeanHypoCone) = GeomMeanHypoConeConstraint(T, cone)
+Base.in(T, cone::GeomMeanHypoCone) = GeomMeanHypoConeConstraint(T, cone)
 
 function AbstractTrees.children(constraint::GeomMeanHypoConeConstraint)
     return (

--- a/src/atoms/sdp_cone/lieb_ando.jl
+++ b/src/atoms/sdp_cone/lieb_ando.jl
@@ -1,6 +1,6 @@
 #############################################################################
 # lieb_ando.jl
-# Returns tr(K' * A^{1-t} * K * B^t) where A and B are positive semidefinite
+# Returns LinearAlgebra.tr(K' * A^{1-t} * K * B^t) where A and B are positive semidefinite
 # matrices and K is an arbitrary matrix (possibly rectangular).
 #
 # Disciplined convex programming information:
@@ -29,7 +29,7 @@ function lieb_ando(
     if t < -1 || t > 2
         throw(DomainError(t, "t must be between -1 and 2"))
     end
-    return real(tr(K' * A^(1 - t) * K * B^t))
+    return real(LinearAlgebra.tr(K' * A^(1 - t) * K * B^t))
 end
 
 function lieb_ando(
@@ -71,8 +71,8 @@ function lieb_ando(
     Kvec = reshape(K', n * m, 1)
     KvKv = Kvec * Kvec'
     KvKv = (KvKv + KvKv') / 2
-    Im = Matrix(1.0 * I, m, m)
-    In = Matrix(1.0 * I, n, n)
+    Im = Matrix(1.0 * LinearAlgebra.I, m, m)
+    In = Matrix(1.0 * LinearAlgebra.I, n, n)
 
     is_complex =
         sign(A) == ComplexSign() ||
@@ -90,14 +90,14 @@ function lieb_ando(
             T,
             T in GeomMeanHypoCone(kron(A, Im), kron(In, conj(B)), t, false),
         )
-        return real(tr(KvKv * T))
+        return real(LinearAlgebra.tr(KvKv * T))
     elseif (t >= -1 && t <= 0) || (t >= 1 && t <= 2)
         # Convex function
         add_constraint!(
             T,
             T in GeomMeanEpiCone(kron(A, Im), kron(In, conj(B)), t, false),
         )
-        return real(tr(KvKv * T))
+        return real(LinearAlgebra.tr(KvKv * T))
     else
         throw(DomainError(t, "t must be between -1 and 2"))
     end

--- a/src/atoms/sdp_cone/matrixfrac.jl
+++ b/src/atoms/sdp_cone/matrixfrac.jl
@@ -25,7 +25,7 @@ end
 
 head(io::IO, ::MatrixFracAtom) = print(io, "matrixfrac")
 
-function sign(m::MatrixFracAtom)
+function Base.sign(m::MatrixFracAtom)
     return Positive()
 end
 

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -53,7 +53,10 @@ function new_conic_form!(context::Context{T}, x::NuclearNormAtom) where {T}
         m, n = size(A)
         U = ComplexVariable(m, m)
         V = ComplexVariable(n, n)
-        p = minimize(real(LinearAlgebra.tr(U) + LinearAlgebra.tr(V)) / 2, [U A; A' V] ⪰ 0)
+        p = minimize(
+            real(LinearAlgebra.tr(U) + LinearAlgebra.tr(V)) / 2,
+            [U A; A' V] ⪰ 0,
+        )
         return conic_form!(context, p)
     else
         t = conic_form!(context, Variable())

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -19,7 +19,7 @@ end
 
 head(io::IO, ::NuclearNormAtom) = print(io, "nuclearnorm")
 
-function sign(x::NuclearNormAtom)
+function Base.sign(x::NuclearNormAtom)
     return Positive()
 end
 
@@ -33,7 +33,7 @@ function curvature(x::NuclearNormAtom)
 end
 
 function evaluate(x::NuclearNormAtom)
-    return sum(svdvals(evaluate(x.children[1])))
+    return sum(LinearAlgebra.svdvals(evaluate(x.children[1])))
 end
 
 nuclearnorm(x::AbstractExpr) = NuclearNormAtom(x)
@@ -42,10 +42,10 @@ nuclearnorm(x::AbstractExpr) = NuclearNormAtom(x)
 # (the operator A is negated but this doesn't affect the norm)
 # https://cs.uwaterloo.ca/~watrous/TQI/TQI.pdf
 function new_conic_form!(context::Context{T}, x::NuclearNormAtom) where {T}
-    A = only(children(x))
+    A = only(AbstractTrees.children(x))
     if iscomplex(sign(A))
         # I'm not sure how to use MOI's `NormNuclearCone` in this case, so we'll just do the extended formulation as an SDP ourselves:
-        #   minimize (tr(U) + tr(V))/2
+        #   minimize (LinearAlgebra.tr(U) + LinearAlgebra.tr(V))/2
         #   subject to
         #            [U A; A' V] ⪰ 0
         # see eg Recht, Fazel, Parillo 2008 "Guaranteed Minimum-Rank Solutions of Linear Matrix Equations via Nuclear Norm Minimization"
@@ -53,7 +53,7 @@ function new_conic_form!(context::Context{T}, x::NuclearNormAtom) where {T}
         m, n = size(A)
         U = ComplexVariable(m, m)
         V = ComplexVariable(n, n)
-        p = minimize(real(tr(U) + tr(V)) / 2, [U A; A' V] ⪰ 0)
+        p = minimize(real(LinearAlgebra.tr(U) + LinearAlgebra.tr(V)) / 2, [U A; A' V] ⪰ 0)
         return conic_form!(context, p)
     else
         t = conic_form!(context, Variable())

--- a/src/atoms/sdp_cone/operatornorm.jl
+++ b/src/atoms/sdp_cone/operatornorm.jl
@@ -5,7 +5,6 @@
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import LinearAlgebra: opnorm
 
 ### Operator norm
 
@@ -21,7 +20,7 @@ end
 
 head(io::IO, ::OperatorNormAtom) = print(io, "opnorm")
 
-function sign(x::OperatorNormAtom)
+function Base.sign(x::OperatorNormAtom)
     return Positive()
 end
 
@@ -36,12 +35,12 @@ end
 
 # in julia, `norm` on matrices is the operator norm
 function evaluate(x::OperatorNormAtom)
-    return opnorm(evaluate(x.children[1]), 2)
+    return LinearAlgebra.opnorm(evaluate(x.children[1]), 2)
 end
 
 sigmamax(x::AbstractExpr) = OperatorNormAtom(x)
 
-function opnorm(x::AbstractExpr, p::Real = 2)
+function LinearAlgebra.opnorm(x::AbstractExpr, p::Real = 2)
     if length(size(x)) <= 1 || minimum(size(x)) == 1
         throw(ArgumentError("argument to `opnorm` must be a matrix"))
     end
@@ -58,7 +57,7 @@ function opnorm(x::AbstractExpr, p::Real = 2)
     end
 end
 
-Base.@deprecate operatornorm(x::AbstractExpr) opnorm(x)
+Base.@deprecate operatornorm(x::AbstractExpr) LinearAlgebra.opnorm(x)
 
 function new_conic_form!(context::Context{T}, x::OperatorNormAtom) where {T}
     A = x.children[1]

--- a/src/atoms/sdp_cone/quantum_entropy.jl
+++ b/src/atoms/sdp_cone/quantum_entropy.jl
@@ -1,5 +1,5 @@
 #############################################################################
-# quantum_entropy returns -tr(X*log(X)) where X is a positive semidefinite.
+# quantum_entropy returns -LinearAlgebra.tr(X*log(X)) where X is a positive semidefinite.
 # Note this function uses logarithm base e, not base 2, so return value is in
 # units of nats, not bits.
 #
@@ -41,7 +41,7 @@ end
 
 head(io::IO, ::QuantumEntropy) = print(io, "quantum_entropy")
 
-function sign(atom::QuantumEntropy)
+function Base.sign(atom::QuantumEntropy)
     return Positive()
 end
 
@@ -67,7 +67,7 @@ end
 
 function quantum_entropy(X::MatrixOrConstant, m::Integer = 0, k::Integer = 0)
     #println("quantum_entropy constant X")
-    return -quantum_relative_entropy(X, Matrix(1.0 * I, size(X)))
+    return -quantum_relative_entropy(X, Matrix(1.0 * LinearAlgebra.I, size(X)))
 end
 
 function new_conic_form!(context::Context, atom::QuantumEntropy)
@@ -75,7 +75,7 @@ function new_conic_form!(context::Context, atom::QuantumEntropy)
     m = atom.m
     k = atom.k
     n = size(X)[1]
-    eye = Matrix(1.0 * I, n, n)
+    eye = Matrix(1.0 * LinearAlgebra.I, n, n)
 
     add_constraint!(context, X ⪰ 0)
 
@@ -88,6 +88,6 @@ function new_conic_form!(context::Context, atom::QuantumEntropy)
     add_constraint!(context, τ in RelativeEntropyEpiCone(X, eye, m, k))
 
     # It's already a real mathematically, but need to make it a real type.
-    τ = real(-tr(τ))
+    τ = real(-LinearAlgebra.tr(τ))
     return conic_form!(context, minimize(τ))
 end

--- a/src/atoms/sdp_cone/quantum_relative_entropy.jl
+++ b/src/atoms/sdp_cone/quantum_relative_entropy.jl
@@ -93,7 +93,9 @@ end
 
 head(io::IO, ::QuantumRelativeEntropy2) = print(io, "quantum_relative_entropy")
 
-Base.sign(atom::Union{QuantumRelativeEntropy1,QuantumRelativeEntropy2}) = Positive()
+function Base.sign(atom::Union{QuantumRelativeEntropy1,QuantumRelativeEntropy2})
+    return Positive()
+end
 
 function monotonicity(atom::QuantumRelativeEntropy1)
     return (NoMonotonicity(), NoMonotonicity())

--- a/src/atoms/sdp_cone/quantum_relative_entropy.jl
+++ b/src/atoms/sdp_cone/quantum_relative_entropy.jl
@@ -1,5 +1,5 @@
 #############################################################################
-# quantum_relative_entropy returns tr(A*(log(A)-log(B))) where A and B
+# quantum_relative_entropy returns LinearAlgebra.tr(A*(log(A)-log(B))) where A and B
 # are positive semidefinite matrices.  Note this function uses logarithm
 # base e, not base 2, so return value is in units of nats, not bits.
 #
@@ -80,7 +80,7 @@ mutable struct QuantumRelativeEntropy2 <: AbstractExpr
         end
 
         # nullspace of A must contain nullspace of B
-        v, U = eigen(Hermitian(B))
+        v, U = LinearAlgebra.eigen(LinearAlgebra.Hermitian(B))
         if any(v .< -nullspace_tol)
             throw(DomainError(B, "B must be positive semidefinite"))
         end
@@ -93,7 +93,7 @@ end
 
 head(io::IO, ::QuantumRelativeEntropy2) = print(io, "quantum_relative_entropy")
 
-sign(atom::Union{QuantumRelativeEntropy1,QuantumRelativeEntropy2}) = Positive()
+Base.sign(atom::Union{QuantumRelativeEntropy1,QuantumRelativeEntropy2}) = Positive()
 
 function monotonicity(atom::QuantumRelativeEntropy1)
     return (NoMonotonicity(), NoMonotonicity())
@@ -172,22 +172,22 @@ function quantum_relative_entropy(
     end
 
     # need to project down to support of A
-    v, U = eigen(Hermitian(A))
+    v, U = LinearAlgebra.eigen(LinearAlgebra.Hermitian(A))
     if any(v .< -nullspace_tol)
         throw(DomainError(A, "A must be positive semidefinite"))
     end
-    if any(eigvals(Hermitian(B)) .< -nullspace_tol)
+    if any(LinearAlgebra.eigvals(LinearAlgebra.Hermitian(B)) .< -nullspace_tol)
         throw(DomainError(B, "B must be positive semidefinite"))
     end
     J = U'[v.>nullspace_tol, :]
-    Ap = Hermitian(J * A * J')
-    Bp = Hermitian(J * B * J')
+    Ap = LinearAlgebra.Hermitian(J * A * J')
+    Bp = LinearAlgebra.Hermitian(J * B * J')
 
-    if any(eigvals(Bp) .< nullspace_tol)
+    if any(LinearAlgebra.eigvals(Bp) .< nullspace_tol)
         return Inf
     end
 
-    return real(tr(Ap * (log(Ap) - log(Bp))))
+    return real(LinearAlgebra.tr(Ap * (log(Ap) - log(Bp))))
 end
 
 function new_conic_form!(context::Context, atom::QuantumRelativeEntropy1)
@@ -196,7 +196,7 @@ function new_conic_form!(context::Context, atom::QuantumRelativeEntropy1)
     m = atom.m
     k = atom.k
     n = size(A)[1]
-    eye = Matrix(1.0 * I, n, n)
+    eye = Matrix(1.0 * LinearAlgebra.I, n, n)
     e = vec(eye)
 
     add_constraint!(context, A ⪰ 0)
@@ -224,10 +224,10 @@ function new_conic_form!(context::Context, atom::QuantumRelativeEntropy2)
     if length(K) > 0
         add_constraint!(context, K * A * K' == 0)
         Ap = J * A * J'
-        Bp = Hermitian(J * B * J')
-        τ = -quantum_entropy(Ap, m, k) - real(tr(Ap * log(Bp)))
+        Bp = LinearAlgebra.Hermitian(J * B * J')
+        τ = -quantum_entropy(Ap, m, k) - real(LinearAlgebra.tr(Ap * log(Bp)))
     else
-        τ = -quantum_entropy(A, m, k) - real(tr(A * log(B)))
+        τ = -quantum_entropy(A, m, k) - real(LinearAlgebra.tr(A * log(B)))
     end
 
     return conic_form!(context, minimize(τ))

--- a/src/atoms/sdp_cone/relative_entropy_epicone.jl
+++ b/src/atoms/sdp_cone/relative_entropy_epicone.jl
@@ -105,7 +105,9 @@ function head(io::IO, ::RelativeEntropyEpiConeConstraint)
     return print(io, "∈(RelativeEntropyEpiCone)")
 end
 
-Base.in(τ, cone::RelativeEntropyEpiCone) = RelativeEntropyEpiConeConstraint(τ, cone)
+function Base.in(τ, cone::RelativeEntropyEpiCone)
+    return RelativeEntropyEpiConeConstraint(τ, cone)
+end
 
 function AbstractTrees.children(constraint::RelativeEntropyEpiConeConstraint)
     return (constraint.τ, constraint.cone.X, constraint.cone.Y)

--- a/src/atoms/sdp_cone/relative_entropy_epicone.jl
+++ b/src/atoms/sdp_cone/relative_entropy_epicone.jl
@@ -30,7 +30,7 @@ mutable struct RelativeEntropyEpiCone
         Y::AbstractExpr,
         m::Integer = 3,
         k::Integer = 3,
-        e::AbstractArray = Matrix(1.0 * I, size(X)),
+        e::AbstractArray = Matrix(1.0 * LinearAlgebra.I, size(X)),
     )
         if size(X) != size(Y)
             throw(DimensionMismatch("X and Y must be the same size"))
@@ -54,7 +54,7 @@ mutable struct RelativeEntropyEpiCone
         Y::AbstractExpr,
         m::Integer = 3,
         k::Integer = 3,
-        e::AbstractArray = Matrix(1.0 * I, size(X)),
+        e::AbstractArray = Matrix(1.0 * LinearAlgebra.I, size(X)),
     )
         return RelativeEntropyEpiCone(constant(X), Y, m, k, e)
     end
@@ -63,7 +63,7 @@ mutable struct RelativeEntropyEpiCone
         Y::Value,
         m::Integer = 3,
         k::Integer = 3,
-        e::AbstractArray = Matrix(1.0 * I, size(X)),
+        e::AbstractArray = Matrix(1.0 * LinearAlgebra.I, size(X)),
     )
         return RelativeEntropyEpiCone(X, constant(Y), m, k, e)
     end
@@ -72,7 +72,7 @@ mutable struct RelativeEntropyEpiCone
         Y::Value,
         m::Integer = 3,
         k::Integer = 3,
-        e::AbstractArray = Matrix(1.0 * I, size(X)),
+        e::AbstractArray = Matrix(1.0 * LinearAlgebra.I, size(X)),
     )
         return RelativeEntropyEpiCone(constant(X), constant(Y), m, k, e)
     end
@@ -105,7 +105,7 @@ function head(io::IO, ::RelativeEntropyEpiConeConstraint)
     return print(io, "∈(RelativeEntropyEpiCone)")
 end
 
-in(τ, cone::RelativeEntropyEpiCone) = RelativeEntropyEpiConeConstraint(τ, cone)
+Base.in(τ, cone::RelativeEntropyEpiCone) = RelativeEntropyEpiConeConstraint(τ, cone)
 
 function AbstractTrees.children(constraint::RelativeEntropyEpiConeConstraint)
     return (constraint.τ, constraint.cone.X, constraint.cone.Y)
@@ -139,8 +139,8 @@ function glquad(m)
     # Clenshaw-Curtis?", SIAM Review 2008] and computes the weights and
     # nodes on [-1, 1].
     beta = [0.5 ./ sqrt(1 - (2 * i)^-2) for i in 1:(m-1)] # 3-term recurrence coeffs
-    T = diagm(1 => beta, -1 => beta) # Jacobi matrix
-    s, V = eigen(T)
+    T = LinearAlgebra.diagm(1 => beta, -1 => beta) # Jacobi matrix
+    s, V = LinearAlgebra.eigen(T)
     w = 2 * V[1, :] .^ 2 # weights
     # Translate and scale to [0, 1]
     s = (s .+ 1) / 2

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -5,9 +5,6 @@
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import LinearAlgebra.eigvals
-
-### sumlargesteigs
 
 mutable struct SumLargestEigs <: AbstractExpr
     children::Tuple{AbstractExpr,AbstractExpr}
@@ -26,7 +23,7 @@ end
 
 head(io::IO, ::SumLargestEigs) = print(io, "sumlargesteigs")
 
-function sign(x::SumLargestEigs)
+function Base.sign(x::SumLargestEigs)
     return NoSign()
 end
 
@@ -39,7 +36,7 @@ function curvature(x::SumLargestEigs)
 end
 
 function evaluate(x::SumLargestEigs)
-    return eigvals(evaluate(x.children[1]))[end-x.children[2]:end]
+    return LinearAlgebra.eigvals(evaluate(x.children[1]))[end-x.children[2]:end]
 end
 
 function sumlargesteigs(x::AbstractExpr, k::Int)
@@ -66,8 +63,8 @@ function new_conic_form!(context::Context{T}, x::SumLargestEigs) where {T}
     s = Variable()
     # Note: we know the trace is real, since Z is PSD, but we need to tell Convex.jl that.
     p = minimize(
-        s * k + real(tr(Z)),
-        [Z - X + s * Matrix(1.0I, n, n) ⪰ 0, Z ⪰ 0, X == X'],
+        s * k + real(LinearAlgebra.tr(Z)),
+        [Z - X + s * Matrix(1.0 * LinearAlgebra.I, n, n) ⪰ 0, Z ⪰ 0, X == X'],
     )
     return conic_form!(context, p)
 end

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -57,4 +57,6 @@ end
 
 geomean(args::AbstractExprOrValue...) = GeoMeanAtom(args...)
 
-Base.sqrt(x::AbstractExpr) = GeoMeanAtom(x, constant(ones(x.size[1], x.size[2])))
+function Base.sqrt(x::AbstractExpr)
+    return GeoMeanAtom(x, constant(ones(x.size[1], x.size[2])))
+end

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -1,5 +1,3 @@
-import Base.sqrt
-
 mutable struct GeoMeanAtom <: AbstractExpr
     children::NTuple{N,AbstractExpr} where {N}
     size::Tuple{Int,Int}
@@ -20,7 +18,7 @@ end
 
 head(io::IO, ::GeoMeanAtom) = print(io, "geomean")
 
-function sign(q::GeoMeanAtom)
+function Base.sign(q::GeoMeanAtom)
     return Positive()
 end
 
@@ -58,4 +56,5 @@ function new_conic_form!(context::Context{T}, q::GeoMeanAtom) where {T}
 end
 
 geomean(args::AbstractExprOrValue...) = GeoMeanAtom(args...)
-sqrt(x::AbstractExpr) = GeoMeanAtom(x, constant(ones(x.size[1], x.size[2])))
+
+Base.sqrt(x::AbstractExpr) = GeoMeanAtom(x, constant(ones(x.size[1], x.size[2])))

--- a/src/atoms/second_order_cone/huber.jl
+++ b/src/atoms/second_order_cone/huber.jl
@@ -16,7 +16,7 @@ end
 
 head(io::IO, ::HuberAtom) = print(io, "huber")
 
-function sign(x::HuberAtom)
+function Base.sign(x::HuberAtom)
     return Positive()
 end
 

--- a/src/atoms/second_order_cone/norm.jl
+++ b/src/atoms/second_order_cone/norm.jl
@@ -1,9 +1,7 @@
-import LinearAlgebra.norm
-
 # deprecate these soon
 norm_inf(x::AbstractExpr) = maximum(abs(x))
 norm_1(x::AbstractExpr) = sum(abs(x))
-norm_fro(x::AbstractExpr) = norm2(vec(x))
+norm_fro(x::AbstractExpr) = LinearAlgebra.norm2(vec(x))
 
 """
     norm(x::AbstractExpr, p::Real=2)
@@ -26,7 +24,7 @@ function LinearAlgebra.norm(x::AbstractExpr, p::Real = 2)
     if p == 1
         return norm_1(x)
     elseif p == 2
-        return norm2(x)
+        return LinearAlgebra.norm2(x)
     elseif p == Inf
         return norm_inf(x)
     elseif p > 1

--- a/src/atoms/second_order_cone/norm2.jl
+++ b/src/atoms/second_order_cone/norm2.jl
@@ -1,10 +1,9 @@
 #############################################################################
-# norm2.jl
+# LinearAlgebra.norm2.jl
 # Handles the euclidean norm (also called frobenius norm for matrices)
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-import LinearAlgebra.norm2
 
 mutable struct EucNormAtom <: AbstractExpr
     children::Tuple{AbstractExpr}
@@ -18,7 +17,7 @@ end
 
 head(io::IO, ::EucNormAtom) = print(io, "norm2")
 
-function sign(x::EucNormAtom)
+function Base.sign(x::EucNormAtom)
     return Positive()
 end
 
@@ -37,9 +36,9 @@ end
 ## Create a new variable euc_norm to represent the norm
 ## Additionally, create the second order conic constraint (euc_norm, x) in SOC
 function new_conic_form!(context::Context{T}, A::EucNormAtom) where {T}
-    obj = conic_form!(context, only(children(A)))
+    obj = conic_form!(context, only(AbstractTrees.children(A)))
 
-    x = only(children(A))
+    x = only(AbstractTrees.children(A))
     d = length(x)
 
     t_obj = conic_form!(context, Variable())
@@ -51,7 +50,7 @@ function new_conic_form!(context::Context{T}, A::EucNormAtom) where {T}
     return t_obj
 end
 
-function norm2(x::AbstractExpr)
+function LinearAlgebra.norm2(x::AbstractExpr)
     if sign(x) == ComplexSign()
         return EucNormAtom([real(x); imag(x)])
     else

--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -29,7 +29,10 @@ function is_psd(
     tol::T = sqrt(eps(T)),
 ) where {T<:AbstractFloat}
     # LDLFactorizations requires the input matrix to only have the upper triangle.
-    A_ = LinearAlgebra.Symmetric(SparseArrays.sparse(LinearAlgebra.UpperTriangular(A)) + tol * LinearAlgebra.I)
+    A_ = LinearAlgebra.Symmetric(
+        SparseArrays.sparse(LinearAlgebra.UpperTriangular(A)) +
+        tol * LinearAlgebra.I,
+    )
     try
         F = LDLFactorizations.ldl(A_)
         d = F.D.diag

--- a/src/atoms/second_order_cone/quadoverlin.jl
+++ b/src/atoms/second_order_cone/quadoverlin.jl
@@ -13,7 +13,7 @@ end
 
 head(io::IO, ::QuadOverLinAtom) = print(io, "qol")
 
-function sign(q::QuadOverLinAtom)
+function Base.sign(q::QuadOverLinAtom)
     return Positive()
 end
 

--- a/src/atoms/second_order_cone/rationalnorm.jl
+++ b/src/atoms/second_order_cone/rationalnorm.jl
@@ -27,7 +27,7 @@ end
 
 head(io::IO, ::RationalNormAtom) = print(io, "rationalnorm")
 
-function sign(x::RationalNormAtom)
+function Base.sign(x::RationalNormAtom)
     return Positive()
 end
 

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -77,7 +77,7 @@ end
 
 AbstractTrees.children(c::ComplexConstant) = tuple()
 vexity(::ComplexConstant) = ConstVexity()
-sign(::ComplexConstant) = ComplexSign()
+Base.sign(::ComplexConstant) = ComplexSign()
 
 function evaluate(c::ComplexConstant)
     return evaluate(c.real_constant) + im * evaluate(c.imag_constant)
@@ -131,11 +131,11 @@ end
 
 evaluate(x::Constant) = output(x.value)
 
-sign(x::Constant) = x.sign
+Base.sign(x::Constant) = x.sign
 
 # We can more efficiently get the length of a constant by asking for the length of its
 # value, which Julia can get via Core.arraylen for arrays and knows is 1 for scalars
-length(x::Constant) = length(x.value)
+Base.length(x::Constant) = length(x.value)
 
 function new_conic_form!(::Context{T}, C::Constant) where {T}
     # this should happen at `Constant` creation?

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -208,10 +208,16 @@ end
 function Base.:+(constraint_one::Constraint, constraint_two::Constraint)
     return [constraint_one] + [constraint_two]
 end
-function Base.:+(constraint_one::Constraint, constraints_two::Array{<:Constraint})
+function Base.:+(
+    constraint_one::Constraint,
+    constraints_two::Array{<:Constraint},
+)
     return [constraint_one] + constraints_two
 end
-function Base.:+(constraints_one::Array{<:Constraint}, constraint_two::Constraint)
+function Base.:+(
+    constraints_one::Array{<:Constraint},
+    constraint_two::Constraint,
+)
     return constraints_one + [constraint_two]
 end
 

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -1,5 +1,3 @@
-import Base.==, Base.<=, Base.>=, Base.<, Base.>
-
 const CONSTANT_CONSTRAINT_TOL = Ref(1e-6)
 
 function iscomplex(constr::Constraint)
@@ -63,9 +61,9 @@ function _add_constraint!(context::Context{T}, eq::EqConstraint) where {T}
     return nothing
 end
 
-==(lhs::AbstractExpr, rhs::AbstractExpr) = EqConstraint(lhs, rhs)
-==(lhs::AbstractExpr, rhs::Value) = ==(lhs, constant(rhs))
-==(lhs::Value, rhs::AbstractExpr) = ==(constant(lhs), rhs)
+Base.:(==)(lhs::AbstractExpr, rhs::AbstractExpr) = EqConstraint(lhs, rhs)
+Base.:(==)(lhs::AbstractExpr, rhs::Value) = ==(lhs, constant(rhs))
+Base.:(==)(lhs::Value, rhs::AbstractExpr) = ==(constant(lhs), rhs)
 
 ### Linear inequality constraints
 mutable struct LtConstraint <: Constraint
@@ -127,12 +125,12 @@ function _add_constraint!(context::Context{T}, lt::LtConstraint) where {T}
     return nothing
 end
 
-<=(lhs::AbstractExpr, rhs::AbstractExpr) = LtConstraint(lhs, rhs)
-<=(lhs::AbstractExpr, rhs::Value) = <=(lhs, constant(rhs))
-<=(lhs::Value, rhs::AbstractExpr) = <=(constant(lhs), rhs)
-<(lhs::AbstractExpr, rhs::AbstractExpr) = LtConstraint(lhs, rhs)
-<(lhs::AbstractExpr, rhs::Value) = <=(lhs, constant(rhs))
-<(lhs::Value, rhs::AbstractExpr) = <=(constant(lhs), rhs)
+Base.:<=(lhs::AbstractExpr, rhs::AbstractExpr) = LtConstraint(lhs, rhs)
+Base.:<=(lhs::AbstractExpr, rhs::Value) = <=(lhs, constant(rhs))
+Base.:<=(lhs::Value, rhs::AbstractExpr) = <=(constant(lhs), rhs)
+Base.:<(lhs::AbstractExpr, rhs::AbstractExpr) = LtConstraint(lhs, rhs)
+Base.:<(lhs::AbstractExpr, rhs::Value) = <=(lhs, constant(rhs))
+Base.:<(lhs::Value, rhs::AbstractExpr) = <=(constant(lhs), rhs)
 
 mutable struct GtConstraint <: Constraint
     lhs::AbstractExpr
@@ -193,27 +191,27 @@ function _add_constraint!(context::Context{T}, gt::GtConstraint) where {T}
     return nothing
 end
 
->=(lhs::AbstractExpr, rhs::AbstractExpr) = GtConstraint(lhs, rhs)
->=(lhs::AbstractExpr, rhs::Value) = >=(lhs, constant(rhs))
->=(lhs::Value, rhs::AbstractExpr) = >=(constant(lhs), rhs)
->(lhs::AbstractExpr, rhs::AbstractExpr) = GtConstraint(lhs, rhs)
->(lhs::AbstractExpr, rhs::Value) = >=(lhs, constant(rhs))
->(lhs::Value, rhs::AbstractExpr) = >=(constant(lhs), rhs)
+Base.:>=(lhs::AbstractExpr, rhs::AbstractExpr) = GtConstraint(lhs, rhs)
+Base.:>=(lhs::AbstractExpr, rhs::Value) = >=(lhs, constant(rhs))
+Base.:>=(lhs::Value, rhs::AbstractExpr) = >=(constant(lhs), rhs)
+Base.:>(lhs::AbstractExpr, rhs::AbstractExpr) = GtConstraint(lhs, rhs)
+Base.:>(lhs::AbstractExpr, rhs::Value) = >=(lhs, constant(rhs))
+Base.:>(lhs::Value, rhs::AbstractExpr) = >=(constant(lhs), rhs)
 
-function +(
+function Base.:+(
     constraints_one::Array{<:Constraint},
     constraints_two::Array{<:Constraint},
 )
     constraints = append!(Constraint[], constraints_one)
     return append!(constraints, constraints_two)
 end
-function +(constraint_one::Constraint, constraint_two::Constraint)
+function Base.:+(constraint_one::Constraint, constraint_two::Constraint)
     return [constraint_one] + [constraint_two]
 end
-function +(constraint_one::Constraint, constraints_two::Array{<:Constraint})
+function Base.:+(constraint_one::Constraint, constraints_two::Array{<:Constraint})
     return [constraint_one] + constraints_two
 end
-function +(constraints_one::Array{<:Constraint}, constraint_two::Constraint)
+function Base.:+(constraints_one::Array{<:Constraint}, constraint_two::Constraint)
     return constraints_one + [constraint_two]
 end
 

--- a/src/constraints/exp_constraints.jl
+++ b/src/constraints/exp_constraints.jl
@@ -60,7 +60,7 @@ function populate_dual!(
     constr::ExpConstraint,
     MOI_constr_indices,
 )
-    x = first(children(constr))
+    x = first(AbstractTrees.children(constr))
     constr.dual = output([
         MOI.get(model, MOI.ConstraintDual(), MOI_constr_indices[i, j]) for
         i in 1:size(x, 1), j in 1:size(x, 2)

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -1,5 +1,3 @@
-import LinearAlgebra.isposdef
-import Base.in
 ### Positive semidefinite cone constraint
 
 # TODO: Terrible documentation. Please fix.
@@ -35,7 +33,7 @@ function _add_constraint!(context::Context, c::SDPConstraint)
             @warn "constant SDP constraint is violated"
             context.detected_infeasible_during_formulation[] = true
         end
-        if !(evaluate(eigmin(c.child)) ≥ -CONSTANT_CONSTRAINT_TOL[])
+        if !(evaluate(LinearAlgebra.eigmin(c.child)) ≥ -CONSTANT_CONSTRAINT_TOL[])
             @warn "constant SDP constraint is violated"
             context.detected_infeasible_during_formulation[] = true
         end
@@ -66,7 +64,7 @@ function populate_dual!(
 end
 
 # TODO: Remove isposdef, change tests to use in. Update documentation and notebooks
-function isposdef(x::AbstractExpr)
+function LinearAlgebra.isposdef(x::AbstractExpr)
     if iscomplex(x)
         SDPConstraint([real(x) -imag(x); imag(x) real(x)])
     else
@@ -74,7 +72,7 @@ function isposdef(x::AbstractExpr)
     end
 end
 
-function in(x::AbstractExpr, y::Symbol)
+function Base.in(x::AbstractExpr, y::Symbol)
     if y == :semidefinite || y == :SDP
         if iscomplex(x)
             SDPConstraint([real(x) -imag(x); imag(x) real(x)])

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -33,7 +33,10 @@ function _add_constraint!(context::Context, c::SDPConstraint)
             @warn "constant SDP constraint is violated"
             context.detected_infeasible_during_formulation[] = true
         end
-        if !(evaluate(LinearAlgebra.eigmin(c.child)) ≥ -CONSTANT_CONSTRAINT_TOL[])
+        if !(
+            evaluate(LinearAlgebra.eigmin(c.child)) ≥
+            -CONSTANT_CONSTRAINT_TOL[]
+        )
             @warn "constant SDP constraint is violated"
             context.detected_infeasible_during_formulation[] = true
         end

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -10,8 +10,6 @@
 # http://web.stanford.edu/~boyd/papers/disc_cvx_prog.html
 #############################################################################
 
-import Base.-, Base.+, Base.*, Base./
-
 # Vexity subtypes
 abstract type Vexity end
 Base.broadcastable(v::Vexity) = Ref(v)
@@ -55,94 +53,94 @@ struct NoSign <: Sign end
 # Also create a new subtype of Sign "NotDefined to handle the ComplexSign case"
 struct ComplexSign <: Sign end
 
--(v::Vexity) = v
--(v::ConcaveVexity) = ConvexVexity()
--(v::ConvexVexity) = ConcaveVexity()
+Base.:-(v::Vexity) = v
+Base.:-(v::ConcaveVexity) = ConvexVexity()
+Base.:-(v::ConvexVexity) = ConcaveVexity()
 
--(m::Monotonicity) = m
--(m::Nonincreasing) = Nondecreasing()
--(m::Nondecreasing) = Nonincreasing()
+Base.:-(m::Monotonicity) = m
+Base.:-(m::Nonincreasing) = Nondecreasing()
+Base.:-(m::Nondecreasing) = Nonincreasing()
 
--(s::Sign) = s
--(s::Positive) = Negative()
--(s::Negative) = Positive()
--(s::ComplexSign) = ComplexSign()
+Base.:-(s::Sign) = s
+Base.:-(s::Positive) = Negative()
+Base.:-(s::Negative) = Positive()
+Base.:-(s::ComplexSign) = ComplexSign()
 
-+(v::NotDcp, w::NotDcp) = v
-+(v::NotDcp, w::Vexity) = v
-+(v::Vexity, w::NotDcp) = w
+Base.:+(v::NotDcp, w::NotDcp) = v
+Base.:+(v::NotDcp, w::Vexity) = v
+Base.:+(v::Vexity, w::NotDcp) = w
 
-+(v::ConstVexity, w::ConstVexity) = v
-+(v::ConstVexity, w::NotDcp) = w
-+(v::NotDcp, w::ConstVexity) = v
-+(v::ConstVexity, w::Vexity) = w
-+(v::Vexity, w::ConstVexity) = v
+Base.:+(v::ConstVexity, w::ConstVexity) = v
+Base.:+(v::ConstVexity, w::NotDcp) = w
+Base.:+(v::NotDcp, w::ConstVexity) = v
+Base.:+(v::ConstVexity, w::Vexity) = w
+Base.:+(v::Vexity, w::ConstVexity) = v
 
-+(v::AffineVexity, w::AffineVexity) = v
-+(v::AffineVexity, w::ConvexVexity) = w
-+(v::ConvexVexity, w::AffineVexity) = v
-+(v::AffineVexity, w::ConcaveVexity) = w
-+(v::ConcaveVexity, w::AffineVexity) = v
+Base.:+(v::AffineVexity, w::AffineVexity) = v
+Base.:+(v::AffineVexity, w::ConvexVexity) = w
+Base.:+(v::ConvexVexity, w::AffineVexity) = v
+Base.:+(v::AffineVexity, w::ConcaveVexity) = w
+Base.:+(v::ConcaveVexity, w::AffineVexity) = v
 
-+(v::ConvexVexity, w::ConvexVexity) = v
-+(v::ConcaveVexity, w::ConcaveVexity) = v
-+(v::ConcaveVexity, w::ConvexVexity) = NotDcp()
-+(v::ConvexVexity, w::ConcaveVexity) = NotDcp()
+Base.:+(v::ConvexVexity, w::ConvexVexity) = v
+Base.:+(v::ConcaveVexity, w::ConcaveVexity) = v
+Base.:+(v::ConcaveVexity, w::ConvexVexity) = NotDcp()
+Base.:+(v::ConvexVexity, w::ConcaveVexity) = NotDcp()
 
-#+(::Convex.Positive, ::Convex.NoSign)
-+(s::Sign) = s
-+(s::Positive, t::Positive) = s
-+(s::Negative, t::Negative) = s
-+(s::Positive, t::Negative) = NoSign()
-+(s::Negative, t::Positive) = NoSign()
-+(s::NoSign, t::NoSign) = s
-+(s::NoSign, t::Positive) = s
-+(t::Positive, s::NoSign) = s + t
-+(s::NoSign, t::Negative) = s
-+(t::Negative, s::NoSign) = s + t
+#Base.:+(::Convex.Positive, ::Convex.NoSign)
+Base.:+(s::Sign) = s
+Base.:+(s::Positive, t::Positive) = s
+Base.:+(s::Negative, t::Negative) = s
+Base.:+(s::Positive, t::Negative) = NoSign()
+Base.:+(s::Negative, t::Positive) = NoSign()
+Base.:+(s::NoSign, t::NoSign) = s
+Base.:+(s::NoSign, t::Positive) = s
+Base.:+(t::Positive, s::NoSign) = s + t
+Base.:+(s::NoSign, t::Negative) = s
+Base.:+(t::Negative, s::NoSign) = s + t
 
 # Any sign + ComplexSign = ComplexSign
-+(s::ComplexSign) = s
-+(s::ComplexSign, t::ComplexSign) = s
-+(s::Sign, t::ComplexSign) = t
-+(t::ComplexSign, s::Sign) = s + t
+Base.:+(s::ComplexSign) = s
+Base.:+(s::ComplexSign, t::ComplexSign) = s
+Base.:+(s::Sign, t::ComplexSign) = t
+Base.:+(t::ComplexSign, s::Sign) = s + t
 
-*(s::NoSign, t::NoSign) = s
-*(s::NoSign, t::Positive) = s
-*(s::Positive, t::NoSign) = t
-*(s::NoSign, t::Negative) = s
-*(s::Negative, t::NoSign) = t
-*(s::Positive, t::Positive) = s
-*(s::Positive, t::Negative) = t
-*(s::Negative, t::Positive) = s
-*(s::Negative, t::Negative) = Positive()
+Base.:*(s::NoSign, t::NoSign) = s
+Base.:*(s::NoSign, t::Positive) = s
+Base.:*(s::Positive, t::NoSign) = t
+Base.:*(s::NoSign, t::Negative) = s
+Base.:*(s::Negative, t::NoSign) = t
+Base.:*(s::Positive, t::Positive) = s
+Base.:*(s::Positive, t::Negative) = t
+Base.:*(s::Negative, t::Positive) = s
+Base.:*(s::Negative, t::Negative) = Positive()
 
 # ComplexSign * Any Sign = NotDefined(Though ComplexSign and its conjugate is real but we ignore that case)
-*(t::ComplexSign, s::ComplexSign) = t
-*(t::ComplexSign, s::Sign) = t
-*(s::Sign, t::ComplexSign) = t
+Base.:*(t::ComplexSign, s::ComplexSign) = t
+Base.:*(t::ComplexSign, s::Sign) = t
+Base.:*(s::Sign, t::ComplexSign) = t
 
-*(s::Positive, m::Monotonicity) = m
-*(s::Negative, m::Monotonicity) = -m
-*(s::NoSign, m::Monotonicity) = NoMonotonicity()
+Base.:*(s::Positive, m::Monotonicity) = m
+Base.:*(s::Negative, m::Monotonicity) = -m
+Base.:*(s::NoSign, m::Monotonicity) = NoMonotonicity()
 
 # ComplexSign * Any monotonivity = NoMonotonicity
-*(s::ComplexSign, m::Monotonicity) = NoMonotonicity()
-*(m::Monotonicity, s::Sign) = s * m
+Base.:*(s::ComplexSign, m::Monotonicity) = NoMonotonicity()
+Base.:*(m::Monotonicity, s::Sign) = s * m
 
-*(m::Nondecreasing, v::Vexity) = v
-*(m::Nonincreasing, v::Vexity) = -v
-*(m::NoMonotonicity, v::Vexity) = v
-*(m::NoMonotonicity, v::ConvexVexity) = NotDcp()
-*(m::NoMonotonicity, v::ConcaveVexity) = NotDcp()
+Base.:*(m::Nondecreasing, v::Vexity) = v
+Base.:*(m::Nonincreasing, v::Vexity) = -v
+Base.:*(m::NoMonotonicity, v::Vexity) = v
+Base.:*(m::NoMonotonicity, v::ConvexVexity) = NotDcp()
+Base.:*(m::NoMonotonicity, v::ConcaveVexity) = NotDcp()
 
 # ComplexSign * Affine = Affine
 # ComplexSign * Concave = NotDcp
 # ComplexSign * NotDcp = NotDcp
 # ComplexSign * NotDcp = NotDcp
-*(s::ComplexSign, v::ConstVexity) = v
-*(s::ComplexSign, v::AffineVexity) = v
-*(s::ComplexSign, v::ConvexVexity) = NotDcp()
-*(s::ComplexSign, v::ConcaveVexity) = NotDcp()
-*(s::ComplexSign, v::NotDcp) = v
-*(v::Vexity, s::ComplexSign) = s * v
+Base.:*(s::ComplexSign, v::ConstVexity) = v
+Base.:*(s::ComplexSign, v::AffineVexity) = v
+Base.:*(s::ComplexSign, v::ConvexVexity) = NotDcp()
+Base.:*(s::ComplexSign, v::ConcaveVexity) = NotDcp()
+Base.:*(s::ComplexSign, v::NotDcp) = v
+Base.:*(v::Vexity, s::ComplexSign) = s * v

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -26,9 +26,6 @@
 #
 #############################################################################
 
-import Base.sign,
-    Base.size, Base.length, Base.lastindex, Base.ndims, Base.convert, Base.axes
-
 ### Abstract types
 abstract type AbstractExpr end
 abstract type Constraint end
@@ -85,15 +82,15 @@ end
 evaluate(x) = output(x) # fallback
 
 # This function should never be reached
-function sign(x::AbstractExpr)
+function Base.sign(x::AbstractExpr)
     return error("sign not implemented for $(x.head).")
 end
 
-function size(x::AbstractExpr)
+function Base.size(x::AbstractExpr)
     return x.size
 end
 
-function length(x::AbstractExpr)
+function Base.length(x::AbstractExpr)
     return prod(x.size)
 end
 
@@ -102,10 +99,10 @@ const Value = Union{Number,AbstractArray}
 const ValueOrNothing = Union{Value,Nothing}
 const AbstractExprOrValue = Union{AbstractExpr,Value}
 
-convert(::Type{AbstractExpr}, x::Value) = constant(x)
-convert(::Type{AbstractExpr}, x::AbstractExpr) = x
+Base.convert(::Type{AbstractExpr}, x::Value) = constant(x)
+Base.convert(::Type{AbstractExpr}, x::AbstractExpr) = x
 
-function size(x::AbstractExpr, dim::Integer)
+function Base.size(x::AbstractExpr, dim::Integer)
     if dim < 1
         error("dimension out of range")
     elseif dim > 2
@@ -115,11 +112,11 @@ function size(x::AbstractExpr, dim::Integer)
     end
 end
 
-ndims(x::AbstractExpr) = 2
-lastindex(x::AbstractExpr) = length(x)
+Base.ndims(x::AbstractExpr) = 2
+Base.lastindex(x::AbstractExpr) = length(x)
 
-axes(x::AbstractExpr) = (Base.OneTo(size(x, 1)), Base.OneTo(size(x, 2)))
-axes(x::AbstractExpr, n::Integer) = axes(x)[n]
-lastindex(x::AbstractExpr, n::Integer) = last(axes(x, n))
+Base.axes(x::AbstractExpr) = (Base.OneTo(size(x, 1)), Base.OneTo(size(x, 2)))
+Base.axes(x::AbstractExpr, n::Integer) = axes(x)[n]
+Base.lastindex(x::AbstractExpr, n::Integer) = last(axes(x, n))
 
 @deprecate get_vectorized_size(x::AbstractExpr) length(x)

--- a/src/problem_depot/problem_depot.jl
+++ b/src/problem_depot/problem_depot.jl
@@ -2,19 +2,20 @@
 # which is available under an MIT license (see LICENSE).
 
 module ProblemDepot
-using BenchmarkTools, Test
-using MathOptInterface
-const MOI = MathOptInterface
+
+using BenchmarkTools
 using Convex
-using LinearAlgebra
-using LinearAlgebra: eigen, I, opnorm
 using Convex: AffineVexity, ConcaveVexity, ConvexVexity
+using Test
+
+import LinearAlgebra
+import MathOptInterface as MOI
 
 randperm(d) = sortperm(rand(d))
 shuffle(x) = x[randperm(length(x))]
 mean(x) = sum(x) / length(x)
-eye(n, T) = Matrix{T}(I, n, n)
-eye(n) = Matrix{Float64}(I, n, n)
+eye(n, T) = Matrix{T}(LinearAlgebra.I, n, n)
+eye(n) = Matrix{Float64}(LinearAlgebra.I, n, n)
 
 """
     const PROBLEMS = Dict{String, Dict{String, Function}}()

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -74,7 +74,7 @@ end
     y = Variable((3, 3))
     p = minimize(
         x + y[1, 1],
-        isposdef(y),
+        LinearAlgebra.isposdef(y),
         x >= 1,
         y[2, 1] == 1;
         numeric_type = T,
@@ -129,8 +129,8 @@ end
     end
     handle_problem!(p)
     if test
-        @test p.optval ≈ sum(svdvals(A)) atol = atol rtol = rtol
-        @test evaluate(nuclearnorm(y)) ≈ sum(svdvals(A)) atol = atol rtol = rtol
+        @test p.optval ≈ sum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
+        @test evaluate(nuclearnorm(y)) ≈ sum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
     end
 end
 
@@ -143,7 +143,7 @@ end
 ) where {T,test}
     y = Variable((3, 3))
     p = minimize(
-        opnorm(y),
+        LinearAlgebra.opnorm(y),
         y[2, 1] <= 4,
         y[2, 2] >= 3,
         sum(y) >= 12;
@@ -156,7 +156,7 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 4 atol = atol rtol = rtol
-        @test evaluate(opnorm(y)) ≈ 4 atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(y)) ≈ 4 atol = atol rtol = rtol
     end
 end
 
@@ -169,15 +169,15 @@ end
 ) where {T,test}
     A = [1 2im 3 4; 4im 3im 2 1; 4 5 6 7]
     y = ComplexVariable(3, 4)
-    p = minimize(opnorm(y), y == A; numeric_type = T)
+    p = minimize(LinearAlgebra.opnorm(y), y == A; numeric_type = T)
 
     if test
         @test problem_vexity(p) == ConvexVexity()
     end
     handle_problem!(p)
     if test
-        @test p.optval ≈ maximum(svdvals(A)) atol = atol rtol = rtol
-        @test evaluate(opnorm(y)) ≈ maximum(svdvals(A)) atol = atol rtol = rtol
+        @test p.optval ≈ maximum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(y)) ≈ maximum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
     end
 end
 
@@ -351,7 +351,7 @@ end
     handle_problem!(p)
 
     if test
-        @test p.optval ≈ sum(eigvals(A)[2:end]) atol = atol rtol = rtol
+        @test p.optval ≈ sum(LinearAlgebra.eigvals(A)[2:end]) atol = atol rtol = rtol
     end
 
     x1 = Semidefinite(3)
@@ -659,7 +659,7 @@ end
 
     handle_problem!(p)
     # test that X is approximately equal to posA:
-    l, v = eigen(A)
+    l, v = LinearAlgebra.eigen(A)
     posA = v * Diagonal(max.(l, 0)) * v'
 
     if test
@@ -1007,7 +1007,7 @@ end
     A = Variable(n, n)
     B = randn(n, n)
     B = B * B' # now A is positive semidefinite
-    B += 0.2 * I # prevent numerical instability
+    B += 0.2 * LinearAlgebra.I # prevent numerical instability
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 0)
     objective = tr(A)
@@ -1031,7 +1031,7 @@ end
     A = Variable(n, n)
     B = randn(n, n)
     B = B * B' # now A is positive semidefinite
-    B += 0.2 * I # prevent numerical instability
+    B += 0.2 * LinearAlgebra.I # prevent numerical instability
 
     c1 = eye(n) in GeomMeanHypoCone(B, A, 1)
     objective = tr(A)
@@ -1054,7 +1054,7 @@ end
     n = 4
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = Variable(n, n)
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 1 // 2)
@@ -1078,7 +1078,7 @@ end
     n = 4
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = Variable(n, n)
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 3 // 8)
@@ -1103,7 +1103,7 @@ end
     n = 4
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = Variable(n, n)
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 3 // 5)
@@ -1128,7 +1128,7 @@ end
     n = 4
     A = randn(ComplexF64, n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = ComplexVariable(n, n)
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 1 // 2)
@@ -1153,7 +1153,7 @@ end
     n = 4
     A = randn(ComplexF64, n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = ComplexVariable(n, n)
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 3 // 8)
@@ -1179,7 +1179,7 @@ end
     n = 4
     A = randn(ComplexF64, n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = ComplexVariable(n, n)
 
     c1 = eye(n) in GeomMeanHypoCone(A, B, 3 // 5)
@@ -1240,7 +1240,7 @@ end
     n = 3
     B = randn(n, n)
     B = B * B' # now B is positive semidefinite
-    B += 0.2 * I # prevent numerical instability
+    B += 0.2 * LinearAlgebra.I # prevent numerical instability
     A = Variable(n, n)
 
     c1 = eye(n) in GeomMeanEpiCone(A, B, -1)
@@ -1265,7 +1265,7 @@ end
     n = 3
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     A /= tr(A) # solver has problems if B is large
     B = Variable(n, n)
 
@@ -1291,7 +1291,7 @@ end
     n = 3
     B = randn(n, n)
     B = B * B' # now B is positive semidefinite
-    B += 0.2 * I # prevent numerical instability
+    B += 0.2 * LinearAlgebra.I # prevent numerical instability
     A = Variable(n, n)
 
     c1 = eye(n) in GeomMeanEpiCone(A, B, -3 // 5)
@@ -1316,7 +1316,7 @@ end
     n = 3
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     A /= tr(A) # solver has problems if B is large
     B = Variable(n, n)
 
@@ -1342,7 +1342,7 @@ end
     n = 3
     B = randn(n, n)
     B = B * B' # now B is positive semidefinite
-    B += 0.2 * I # prevent numerical instability
+    B += 0.2 * LinearAlgebra.I # prevent numerical instability
     B /= tr(B) # solver has problems if B is large
     A = Variable(n, n)
 
@@ -1368,7 +1368,7 @@ end
     n = 3
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     B = Variable(n, n)
 
     c1 = eye(n) in GeomMeanEpiCone(A, B, 8 // 5)
@@ -1731,11 +1731,11 @@ end
 
     for cplx in [false, true]
         if cplx
-            ψ1 = normalize(randn(ComplexF64, n))
-            ψ2 = normalize(randn(ComplexF64, n))
+            ψ1 = LinearAlgebra.normalize(randn(ComplexF64, n))
+            ψ2 = LinearAlgebra.normalize(randn(ComplexF64, n))
         else
-            ψ1 = normalize(randn(Float64, n))
-            ψ2 = normalize(randn(Float64, n))
+            ψ1 = LinearAlgebra.normalize(randn(Float64, n))
+            ψ2 = LinearAlgebra.normalize(randn(Float64, n))
         end
         ρ1 = ψ1 * ψ1'
         ρ2 = ψ2 * ψ2'
@@ -1956,7 +1956,7 @@ end
     n = 3
     A = randn(n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     C = randn(n, n)
     C = C * C' # now C is positive semidefinite
     t = -1 // 4
@@ -1992,7 +1992,7 @@ end
     n = 3
     A = randn(ComplexF64, n, n)
     A = A * A' # now A is positive semidefinite
-    A += 0.2 * I # prevent numerical instability
+    A += 0.2 * LinearAlgebra.I # prevent numerical instability
     C = randn(ComplexF64, n, n)
     C = C * C' # now C is positive semidefinite
     t = -1 // 4
@@ -2268,7 +2268,7 @@ end
     H = rand(ComplexF64, d₁ * d₂, d₁ * d₂)
     U = exp(im * π * (H + H'))
     K = rand(ComplexF64, d₁ * d₂, d₁ * d₂)
-    K *= d₁ / LinearAlgebra.tr(K' * K)
+    K *= d₁ / tr(K' * K)
     ρ = Semidefinite(d₂)
     J = sum(
         kron(
@@ -2276,7 +2276,7 @@ end
             partialtrace(
                 U' *
                 (
-                    K * kron(((1:d₁) .== j) * ((1:d₁) .== k)', I(d₂)) * K' -
+                    K * kron(((1:d₁) .== j) * ((1:d₁) .== k)', LinearAlgebra.I(d₂)) * K' -
                     kron(((1:d₁) .== j) * ((1:d₁) .== k)', ρ)
                 ) *
                 U,
@@ -2286,10 +2286,10 @@ end
         ) for j in 1:d₁, k in 1:d₁
     )
     constraints = [tr(ρ) == 1]
-    p = minimize(opnorm(J, Inf), constraints; numeric_type = T)
+    p = minimize(LinearAlgebra.opnorm(J, Inf), constraints; numeric_type = T)
     handle_problem!(p)
     if test
-        @test p.optval ≈ opnorm(evaluate(J), Inf) atol = atol rtol = rtol
+        @test p.optval ≈ LinearAlgebra.opnorm(evaluate(J), Inf) atol = atol rtol = rtol
         @test tr(evaluate(ρ)) ≈ 1 atol = atol rtol = rtol
     end
 end

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -130,7 +130,8 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ sum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
-        @test evaluate(nuclearnorm(y)) ≈ sum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
+        @test evaluate(nuclearnorm(y)) ≈ sum(LinearAlgebra.svdvals(A)) atol =
+            atol rtol = rtol
     end
 end
 
@@ -176,8 +177,10 @@ end
     end
     handle_problem!(p)
     if test
-        @test p.optval ≈ maximum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
-        @test evaluate(LinearAlgebra.opnorm(y)) ≈ maximum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
+        @test p.optval ≈ maximum(LinearAlgebra.svdvals(A)) atol = atol rtol =
+            rtol
+        @test evaluate(LinearAlgebra.opnorm(y)) ≈
+              maximum(LinearAlgebra.svdvals(A)) atol = atol rtol = rtol
     end
 end
 
@@ -351,7 +354,8 @@ end
     handle_problem!(p)
 
     if test
-        @test p.optval ≈ sum(LinearAlgebra.eigvals(A)[2:end]) atol = atol rtol = rtol
+        @test p.optval ≈ sum(LinearAlgebra.eigvals(A)[2:end]) atol = atol rtol =
+            rtol
     end
 
     x1 = Semidefinite(3)
@@ -2276,8 +2280,12 @@ end
             partialtrace(
                 U' *
                 (
-                    K * kron(((1:d₁) .== j) * ((1:d₁) .== k)', LinearAlgebra.I(d₂)) * K' -
-                    kron(((1:d₁) .== j) * ((1:d₁) .== k)', ρ)
+                    K *
+                    kron(
+                        ((1:d₁) .== j) * ((1:d₁) .== k)',
+                        LinearAlgebra.I(d₂),
+                    ) *
+                    K' - kron(((1:d₁) .== j) * ((1:d₁) .== k)', ρ)
                 ) *
                 U,
                 2,
@@ -2289,7 +2297,8 @@ end
     p = minimize(LinearAlgebra.opnorm(J, Inf), constraints; numeric_type = T)
     handle_problem!(p)
     if test
-        @test p.optval ≈ LinearAlgebra.opnorm(evaluate(J), Inf) atol = atol rtol = rtol
+        @test p.optval ≈ LinearAlgebra.opnorm(evaluate(J), Inf) atol = atol rtol =
+            rtol
         @test tr(evaluate(ρ)) ≈ 1 atol = atol rtol = rtol
     end
 end

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -536,10 +536,14 @@ end
     set_value!(x, A)
     # Matrix norm
     if test
-        @test evaluate(LinearAlgebra.opnorm(x)) ≈ LinearAlgebra.opnorm(A) atol = atol rtol = rtol
-        @test evaluate(LinearAlgebra.opnorm(x, 1)) ≈ LinearAlgebra.opnorm(A, 1) atol = atol rtol = rtol
-        @test evaluate(LinearAlgebra.opnorm(x, 2)) ≈ LinearAlgebra.opnorm(A, 2) atol = atol rtol = rtol
-        @test evaluate(LinearAlgebra.opnorm(x, Inf)) ≈ LinearAlgebra.opnorm(A, Inf) atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x)) ≈ LinearAlgebra.opnorm(A) atol =
+            atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x, 1)) ≈ LinearAlgebra.opnorm(A, 1) atol =
+            atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x, 2)) ≈ LinearAlgebra.opnorm(A, 2) atol =
+            atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x, Inf)) ≈
+              LinearAlgebra.opnorm(A, Inf) atol = atol rtol = rtol
     end
     # Vector norm
     if test

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -536,10 +536,10 @@ end
     set_value!(x, A)
     # Matrix norm
     if test
-        @test evaluate(opnorm(x)) ≈ opnorm(A) atol = atol rtol = rtol
-        @test evaluate(opnorm(x, 1)) ≈ opnorm(A, 1) atol = atol rtol = rtol
-        @test evaluate(opnorm(x, 2)) ≈ opnorm(A, 2) atol = atol rtol = rtol
-        @test evaluate(opnorm(x, Inf)) ≈ opnorm(A, Inf) atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x)) ≈ LinearAlgebra.opnorm(A) atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x, 1)) ≈ LinearAlgebra.opnorm(A, 1) atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x, 2)) ≈ LinearAlgebra.opnorm(A, 2) atol = atol rtol = rtol
+        @test evaluate(LinearAlgebra.opnorm(x, Inf)) ≈ LinearAlgebra.opnorm(A, Inf) atol = atol rtol = rtol
     end
     # Vector norm
     if test

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -97,7 +97,7 @@ vexity(p::Problem) = objective_vexity(p)
 #     return obj_vexity + constr_vexity
 # end
 
-for f in (:sign, :monotonicity, :curvature)
+for f in (:monotonicity, :curvature)
     @eval function $f(p::Problem)
         if p.head === :satisfy
             error("Satisfiability problem cannot be used as subproblem")
@@ -108,6 +108,18 @@ for f in (:sign, :monotonicity, :curvature)
         else
             return m
         end
+    end
+end
+
+function Base.sign(p::Problem)
+    if p.head === :satisfy
+        error("Satisfiability problem cannot be used as subproblem")
+    end
+    m = sign(p.objective)
+    if p.head === :maximize
+        return (-).(m)
+    else
+        return m
     end
 end
 

--- a/src/real_operate.jl
+++ b/src/real_operate.jl
@@ -146,7 +146,7 @@ function real_operate(
 ) where {T<:Real}
     op1 = SparseAffineOperation(tape1)
     op2 = SparseAffineOperation(tape2)
-    A = blockdiag(op1.matrix, op2.matrix)
+    A = SparseArrays.blockdiag(op1.matrix, op2.matrix)
     b = vcat(op1.vector, op2.vector)
     x = vcat(tape1.variables, tape2.variables)
     return SparseTape(SparseAffineOperation(A, b), x)
@@ -228,7 +228,7 @@ function real_operate(
 ) where {T<:Real}
     all_args = (arg1, arg2, arg3, args...)
     ops = SparseAffineOperation.(all_args)
-    A = blockdiag((op.matrix for op in ops)...)
+    A = SparseArrays.blockdiag((op.matrix for op in ops)...)
     b = vcat((op.vector for op in ops)...)
     x = vcat((arg.variables for arg in all_args)...)
     return SparseTape(SparseAffineOperation(A, b), x)

--- a/src/utilities/iteration.jl
+++ b/src/utilities/iteration.jl
@@ -1,5 +1,3 @@
-import Base.iterate
-
-function iterate(x::AbstractVariable, s = 0)
+function Base.iterate(x::AbstractVariable, s = 0)
     return s >= length(x) ? nothing : (x[s+1], s + 1)
 end

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -1,4 +1,3 @@
-import Base.show, Base.summary
 using .TreePrint
 
 """
@@ -100,7 +99,7 @@ end
 
 # A Constant is simply a wrapper around a native Julia constant
 # Hence, we simply display its value
-show(io::IO, x::Union{Constant,ComplexConstant}) = print(io, evaluate(x))
+Base.show(io::IO, x::Union{Constant,ComplexConstant}) = print(io, evaluate(x))
 
 # A variable, for example, Variable(3, 4), will be displayed as:
 # julia> Variable(3,4)
@@ -110,7 +109,7 @@ show(io::IO, x::Union{Constant,ComplexConstant}) = print(io, evaluate(x))
 # vexity: affine
 # id: 758…633
 # here, the `id` will change from run to run.
-function show(io::IO, x::AbstractVariable)
+function Base.show(io::IO, x::AbstractVariable)
     print(io, "Variable")
     print(io, "\nsize: $(size(x))")
     print(io, "\nsign: ")
@@ -159,7 +158,7 @@ function AbstractTrees.printnode(io::IO, c::ConstraintRoot)
     return AbstractTrees.printnode(io, c.constraint)
 end
 
-show(io::IO, c::Constraint) = print_tree_rstrip(io, c)
+Base.show(io::IO, c::Constraint) = print_tree_rstrip(io, c)
 
 struct ExprRoot
     expr::AbstractExpr
@@ -172,7 +171,7 @@ function AbstractTrees.printnode(io::IO, e::ExprRoot)
     return AbstractTrees.printnode(io, e.expr)
 end
 
-show(io::IO, e::AbstractExpr) = print_tree_rstrip(io, e)
+Base.show(io::IO, e::AbstractExpr) = print_tree_rstrip(io, e)
 
 struct ProblemObjectiveRoot
     head::Symbol
@@ -210,7 +209,7 @@ function TreePrint.print_tree(io::IO, p::Problem, args...; kwargs...)
     end
 end
 
-function show(io::IO, p::Problem)
+function Base.show(io::IO, p::Problem)
     TreePrint.print_tree(io, p, MAXDEPTH[], MAXWIDTH[])
     if p.status == MOI.OPTIMIZE_NOT_CALLED
         print(io, "\nstatus: `solve!` not called yet")

--- a/src/utilities/tree_print.jl
+++ b/src/utilities/tree_print.jl
@@ -6,7 +6,7 @@
 # See LICENSE for a copy of its MIT license.
 module TreePrint
 
-using AbstractTrees: children, printnode
+import AbstractTrees
 
 # Printing
 struct TreeCharSet
@@ -91,7 +91,7 @@ function _print_tree(
         println(io, line)
     end
     depth > maxdepth && return
-    c = children(tree)
+    c = AbstractTrees.children(tree)
     if !isempty(c)
         width = 0
         s = Iterators.Stateful(
@@ -136,7 +136,7 @@ function print_tree(f::Function, io::IO, tree, args...; kwargs...)
     return _print_tree(f, io, tree, args...; kwargs...)
 end
 function print_tree(io::IO, tree, args...; kwargs...)
-    return print_tree(printnode, io, tree, args...; kwargs...)
+    return print_tree(AbstractTrees.printnode, io, tree, args...; kwargs...)
 end
 function print_tree(tree, args...; kwargs...)
     return print_tree(stdout::IO, tree, args...; kwargs...)

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -83,11 +83,11 @@ by [`fix!`](@ref) and [`free!`](@ref).
 vexity!(x::AbstractVariable, v::Vexity) = x.vexity = v
 
 """
-    sign(x::AbstractVariable)
+    Base.sign(x::AbstractVariable)
 
 Returns the current sign of `x`.
 """
-sign(x::AbstractVariable) = x.sign
+Base.sign(x::AbstractVariable) = x.sign
 
 """
     sign!(x::AbstractVariable, s::Sign)
@@ -260,7 +260,7 @@ mutable struct ComplexVariable <: AbstractVariable
 end
 
 vartype(::ComplexVariable) = ContVar
-sign(::ComplexVariable) = ComplexSign()
+Base.sign(::ComplexVariable) = ComplexSign()
 
 Variable(size::Tuple{Int,Int}, sign::Sign) = Variable(size, sign, ContVar)
 function Variable(size::Tuple{Int,Int}, vartype::VarType)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -789,7 +789,7 @@ function Convex.vexity!(x::DictVector, v::Convex.Vexity)
     return global_cache[x.id_hash][:vexity] = v
 end
 
-Base.sign(x::DictVector) = global_cache[x.id_hash][:sign]
+Convex.sign(x::DictVector) = global_cache[x.id_hash][:sign]
 
 Convex.sign!(x::DictVector, s::Convex.Sign) = global_cache[x.id_hash][:sign] = s
 
@@ -850,7 +850,7 @@ end
 
 Convex.get_constraints(ρ::DensityMatrix) = [ρ ⪰ 0, tr(ρ) == 1]
 
-Base.sign(::DensityMatrix) = Convex.ComplexSign()
+Convex.sign(::DensityMatrix) = Convex.ComplexSign()
 
 Convex.vartype(::DensityMatrix) = Convex.ContVar
 
@@ -901,7 +901,7 @@ end
 
 Convex.get_constraints(p::ProbabilityVector) = [sum(p) == 1]
 
-Base.sign(::ProbabilityVector) = Convex.Positive()
+Convex.sign(::ProbabilityVector) = Convex.Positive()
 
 Convex.vartype(::ProbabilityVector) = Convex.ContVar
 

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -789,7 +789,7 @@ function Convex.vexity!(x::DictVector, v::Convex.Vexity)
     return global_cache[x.id_hash][:vexity] = v
 end
 
-Convex.sign(x::DictVector) = global_cache[x.id_hash][:sign]
+Base.sign(x::DictVector) = global_cache[x.id_hash][:sign]
 
 Convex.sign!(x::DictVector, s::Convex.Sign) = global_cache[x.id_hash][:sign] = s
 
@@ -850,7 +850,7 @@ end
 
 Convex.get_constraints(ρ::DensityMatrix) = [ρ ⪰ 0, tr(ρ) == 1]
 
-Convex.sign(::DensityMatrix) = Convex.ComplexSign()
+Base.sign(::DensityMatrix) = Convex.ComplexSign()
 
 Convex.vartype(::DensityMatrix) = Convex.ContVar
 
@@ -901,7 +901,7 @@ end
 
 Convex.get_constraints(p::ProbabilityVector) = [sum(p) == 1]
 
-Convex.sign(::ProbabilityVector) = Convex.Positive()
+Base.sign(::ProbabilityVector) = Convex.Positive()
 
 Convex.vartype(::ProbabilityVector) = Convex.ContVar
 


### PR DESCRIPTION
There were lots of imports scattered around the code that make it hard to know what functions were defined by Convex, and what were overloaded. One example is `Base.sign`, which was imported in `src/expressions.jl`. 

The exports, e.g., from LinearAlgebra, are retained.<s>, so the only breaking part about this is `Convex.sign` to `Base.sign`, and we can't fix this by exporting because it's a `Base` method.</s>