### PR TITLE
remove internal function `latex_formulation`

### DIFF
--- a/src/solution.jl
+++ b/src/solution.jl
@@ -16,24 +16,6 @@ scalar_fn(x::SparseTape) = scalar_fn(to_vaf(x))
 scalar_fn(v::MOI.AbstractScalarFunction) = v
 
 """
-    latex_formulation(problem::Problem, optimizer=MOI.Utilities.Model{Float64})
-
-Prints a LaTeX formulation of the problem. Optionally, pass an `optimizer`
-(like `SCS.Optimizer`) as the second argument, to see the formulation provided
-for that specific optimizer (since MathOptInterface will reformulate
-the problem based on what the optimizer can support).
-
-Uses `MathOptInterface.Utilities.latex_formulation`.
-"""
-function latex_formulation(
-    problem::Problem,
-    optimizer = MOI.Utilities.Model{Float64},
-)
-    context = Context(problem, optimizer)
-    return MOI.Utilities.latex_formulation(context.model)
-end
-
-"""
     solve!(problem::Problem, optimizer_factory;
         silent_solver = false,
     )

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -16,7 +16,7 @@ scalar_fn(x::SparseTape) = scalar_fn(to_vaf(x))
 scalar_fn(v::MOI.AbstractScalarFunction) = v
 
 """
-    latex_formulation(problem::Problem, optimizer=MOI.Utilities.Model{Float64}())
+    latex_formulation(problem::Problem, optimizer=MOI.Utilities.Model{Float64})
 
 Prints a LaTeX formulation of the problem. Optionally, pass an `optimizer`
 (like `SCS.Optimizer`) as the second argument, to see the formulation provided
@@ -27,7 +27,7 @@ Uses `MathOptInterface.Utilities.latex_formulation`.
 """
 function latex_formulation(
     problem::Problem,
-    optimizer = MOI.Utilities.Model{Float64}(),
+    optimizer = MOI.Utilities.Model{Float64},
 )
     context = Context(problem, optimizer)
     return MOI.Utilities.latex_formulation(context.model)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -936,6 +936,20 @@ function test_write_to_file()
     return
 end
 
+function test_latex_formulation()
+    x = Variable(3)
+    p = minimize(logsumexp(x))
+    for latex_model in (
+        Convex.latex_formulation(p),
+        Convex.latex_formulation(p, SCS.Optimizer),
+    )
+        str = sprint(show, latex_model)
+        @test contains(str, "ExponentialCone()")
+        @test contains(str, "Nonnegatives(1)")
+    end
+    return
+end
+
 end  # TestUtilities
 
 TestUtilities.runtests()

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -936,20 +936,6 @@ function test_write_to_file()
     return
 end
 
-function test_latex_formulation()
-    x = Variable(3)
-    p = minimize(logsumexp(x))
-    for latex_model in (
-        Convex.latex_formulation(p),
-        Convex.latex_formulation(p, SCS.Optimizer),
-    )
-        str = sprint(show, latex_model)
-        @test contains(str, "ExponentialCone()")
-        @test contains(str, "Nonnegatives(1)")
-    end
-    return
-end
-
 end  # TestUtilities
 
 TestUtilities.runtests()


### PR DESCRIPTION
I think I initially was using this code for debugging at some point in #504, but it was untested and bitrotted. Here I've added a test, I guess we could also export it and add it to the release notes. Alternatively we could delete it.