### PR TITLE
Rename to old names in changelog

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -27,8 +27,8 @@ changes.
       dual variable associated with such constraints is now reversed in sign**.
       (Following the convention in MathOptInterface, the dual of `a <= b` is
       always negative, regardless of optimization sense.) (#593)
-    * The structs `LessThanConstraint`, `GreaterThanConstraint`, `EqualToConstraint`
-      `SecondOrderConeConstraint` and `PostiveSemidefinteConeConstraint` have
+    * The structs `LtConstraint`, `GtConstraint`, `EqConstraint`
+      `SOCConstraint` and `SDPConstraint` have
       been replaced by `GenericConstraint{S}` where `S<:MOI.AbstractSet` (#590)
  * The syntaxes `dot(*)`, `dot(/)` and `dot(^)` have been removed in favor of
    explicit broadcasting (`x .* y`, `x ./ y`, and `x .^ y`). These were (mild)


### PR DESCRIPTION
The renaming hasn't been released so that's still how they are called in the current release