### PR TITLE
Add default set_with_size

### DIFF
--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -12,6 +12,14 @@ function GenericConstraint{S}(child::AbstractExpr) where {S<:MOI.AbstractSet}
     return GenericConstraint(child, set_with_size(S, size(child)))
 end
 
+function set_with_size(::Type{S}, sz::Tuple{Int,Int}) where {S<:MOI.AbstractVectorSet}
+    if sz[2] != 1
+        error("Cannot constrain a matrix of size `$sz` to be long to the cone" *
+            "`$S``, there should be only one column.")
+    end
+    return MOI.Utilities.set_with_dimension(S, sz[1])
+end
+
 head(io::IO, c::GenericConstraint) = head(io, c.set)
 
 # A default fallback that skips the feasibiltiy check.
@@ -230,10 +238,6 @@ end
 # ==============================================================================
 #     SecondOrderCone
 # ==============================================================================
-
-function set_with_size(::Type{MOI.SecondOrderCone}, sz::Tuple{Int,Int})
-    return MOI.SecondOrderCone(prod(sz))
-end
 
 head(io::IO, ::MOI.SecondOrderCone) = print(io, "soc")
 

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -12,10 +12,15 @@ function GenericConstraint{S}(child::AbstractExpr) where {S<:MOI.AbstractSet}
     return GenericConstraint(child, set_with_size(S, size(child)))
 end
 
-function set_with_size(::Type{S}, sz::Tuple{Int,Int}) where {S<:MOI.AbstractVectorSet}
+function set_with_size(
+    ::Type{S},
+    sz::Tuple{Int,Int},
+) where {S<:MOI.AbstractVectorSet}
     if sz[2] != 1
-        error("Cannot constrain a matrix of size `$sz` to be long to the cone" *
-            "`$S``, there should be only one column.")
+        error(
+            "Cannot constrain a matrix of size `$sz` to be long to the cone" *
+            "`$S``, there should be only one column.",
+        )
     end
     return MOI.Utilities.set_with_dimension(S, sz[1])
 end

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -19,7 +19,7 @@ function set_with_size(
     if sz[2] != 1
         error(
             "Cannot constrain a matrix of size `$sz` to be long to the cone " *
-            "`$S``, there should be only one column.",
+            "`$S`, there should be only one column.",
         )
     end
     return MOI.Utilities.set_with_dimension(S, sz[1])

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -18,7 +18,7 @@ function set_with_size(
 ) where {S<:MOI.AbstractVectorSet}
     if sz[2] != 1
         error(
-            "Cannot constrain a matrix of size `$sz` to be long to the cone" *
+            "Cannot constrain a matrix of size `$sz` to be long to the cone " *
             "`$S``, there should be only one column.",
         )
     end

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -239,6 +239,20 @@ function test_GenericConstraint_SecondOrderCone()
     return
 end
 
+function test_GenericConstraint_SecondOrderCone_set_with_size()
+    x = Variable(2, 2)
+    S = MOI.SecondOrderCone
+    sz = size(x)
+    @test_throws(
+        ErrorException(
+            "Cannot constrain a matrix of size `$sz` to be long to the cone " *
+            "`$S``, there should be only one column.",
+        ),
+        Convex.GenericConstraint{S}(x),
+    )
+    return
+end
+
 end  # TestConstraints
 
 TestConstraints.runtests()

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -246,7 +246,7 @@ function test_GenericConstraint_SecondOrderCone_set_with_size()
     @test_throws(
         ErrorException(
             "Cannot constrain a matrix of size `$sz` to be long to the cone " *
-            "`$S``, there should be only one column.",
+            "`$S`, there should be only one column.",
         ),
         Convex.GenericConstraint{S}(x),
     )


### PR DESCRIPTION
I'm not sure we should allow matrices with more than one columns to be constrained to SOC. We can have for a user coming up for a good motivation and leave it as error at least for now.