### PR TITLE
Replace is_feasible by distance_to_set

### DIFF
--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -20,7 +20,7 @@ vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 
 function _add_constraint!(context::Context, c::GenericConstraint)
     if vexity(c.child) == ConstVexity()
-        dist = MOI.Utilities.distance_to_set(evaluate(c.child), set)
+        dist = MOI.Utilities.distance_to_set(evaluate(c.child), c.set)
         if dist > CONSTANT_CONSTRAINT_TOL[]
             context.detected_infeasible_during_formulation[] = true
         end

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -21,6 +21,10 @@ AbstractTrees.children(c::GenericConstraint) = (c.child,)
 function is_feasible(x, set, tol)
     return MOI.Utilities.distance_to_set(x, set) <= tol
 end
+
+function is_feasible(x::Number, set::MOI.AbstractVectorSet, tol)
+    return is_feasible([x], set, tol)
+end
     
 vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -25,7 +25,6 @@ end
 function is_feasible(x::Number, set::MOI.AbstractVectorSet, tol)
     return is_feasible([x], set, tol)
 end
-    
 vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 
 function _add_constraint!(context::Context, c::GenericConstraint)

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -25,6 +25,7 @@ end
 function is_feasible(x::Number, set::MOI.AbstractVectorSet, tol)
     return is_feasible([x], set, tol)
 end
+
 vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 
 function _add_constraint!(context::Context, c::GenericConstraint)


### PR DESCRIPTION
I think a default fallback returning `true` is incorrect. Since the constraint is not added when it is constant, we should check that it is feasible otherwise the infeasibility is silently ignored and the resulting status is incorrect.