### PR TITLE
optimize `ExpAtom`

### DIFF
--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -45,10 +45,10 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
     # First, we will get `x` as an MOI.VectorAffineFunction
     x_tape = conic_form!(context, x)
-    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `Vector{T}` or `SparseTape{T}`.
-    # The `Vector{T}` case happens when `x` is a constant (or a function of a constant).
+    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `SPARSE_VECTOR{T}` or `SparseTape{T}`.
+    # The `SPARSE_VECTOR{T}` case happens when `x` is a constant (or a function of a constant).
     # In this case, we can just take `exp` directly.
-    if x_tape isa Vector
+    if x_tape isa SPARSE_VECTOR
         return exp.(x_tape)
     end
     vaf = to_vaf(x_tape)

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -36,8 +36,8 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     z = Variable(m, n)
     # Naive implementation:
     # for i in 1:m, j in 1:n
-    # f = vcat(x[i, j], 1, z[i, j])
-        # add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    #     f = vcat(x[i, j], 1, z[i, j])
+    #     add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
     # end
     # return conic_form!(context, z)
     # This is slow, since we are indexing on the Convex side, and convex is based around
@@ -59,7 +59,7 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
         # So we can't use `MOI.Utilities.vectorize`. Instead, we will construct a VectorAffineFunction manually.
         # First, we construct the VectorAffineTerm's for the first and third components.
         terms = [
-            [MOI.VectorAffineTerm(Int64(1), sat) for sat in xs[i].terms];
+            [MOI.VectorAffineTerm(Int64(1), sat) for sat in xs[i].terms]
             MOI.VectorAffineTerm(Int64(3), MOI.ScalarAffineTerm(T(1), zs[i]))
         ]
         # Then we can add in the constants, and we are good to go.

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -53,7 +53,7 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
 
     z_tape = conic_form!(context, z)
 
-    xs = MOI.Utilities.scalarize(to_vaf(x + tapi))
+    xs = MOI.Utilities.scalarize(to_vaf(x_tape))
     # Now we have a vector of `m*n` ScalarAffineFunctions in order.
 
     # We just created `z`, so we know the operation is trivial.

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -34,9 +34,37 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     x = e.children[1]
     m, n = size(x)
     z = Variable(m, n)
-    for i in 1:m, j in 1:n
-        f = vcat(x[i, j], 1, z[i, j])
-        add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    # Naive implementation:
+    # for i in 1:m, j in 1:n
+    # f = vcat(x[i, j], 1, z[i, j])
+        # add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    # end
+    # return conic_form!(context, z)
+    # This is slow, since we are indexing on the Convex side, and convex is based around
+    # vector/matrix operations. We don't want to produce n*m IndexAtoms!
+    # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
+    # First, we will get `x` as an MOI.VectorAffineFunction
+    x_tape = conic_form!(context, x)
+    vaf = to_vaf(x_tape)
+    # Next, we can extract the individual components of `x` via `MOI.Utilities.scalarize`
+    xs = MOI.Utilities.scalarize(vaf)
+    # Now we have a vector of `m*n` ScalarAffineFunctions in order.
+    # We can likewise lower `z` to a vector of `MOI.VariableIndex`
+    z_tape = conic_form!(context, z)
+    zs = z_tape.variables
+    for i in eachindex(xs, zs)
+        # Now, we wish to add the constraint `(x[i], 1, z[i]) ∈ MOI.ExponentialCone()`
+        # however, we have 3 different types: x[i] is a ScalarAffineFunction, 1 is a constant,
+        # and `z` is a VariableIndex.
+        # So we can't use `MOI.Utilities.vectorize`. Instead, we will construct a VectorAffineFunction manually.
+        # First, we construct the VectorAffineTerm's for the first and third components.
+        terms = [
+            [MOI.VectorAffineTerm(Int64(1), sat) for sat in xs[i].terms];
+            MOI.VectorAffineTerm(Int64(3), MOI.ScalarAffineTerm(T(1), zs[i]))
+        ]
+        # Then we can add in the constants, and we are good to go.
+        vaf_i = MOI.VectorAffineFunction(terms, [xs[i].constant, T(1), T(0)])
+        MOI.add_constraint(context.model, vaf_i, MOI.ExponentialCone())
     end
-    return conic_form!(context, z)
+    return z_tape
 end

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -45,6 +45,12 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
     # First, we will get `x` as an MOI.VectorAffineFunction
     x_tape = conic_form!(context, x)
+    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `Vector{T}` or `SparseTape{T}`.
+    # The `Vector{T}` case happens when `x` is a constant (or a function of a constant).
+    # In this case, we can just take `exp` directly.
+    if x_tape isa Vector
+        return exp.(x_tape)
+    end
     vaf = to_vaf(x_tape)
     # Next, we can extract the individual components of `x` via `MOI.Utilities.scalarize`
     xs = MOI.Utilities.scalarize(vaf)

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -24,14 +24,14 @@
 
     # Test for constant `exp` (#613)
     y = Variable()
-    x = constant([1,2,3])
+    x = constant([1, 2, 3])
     p = minimize(sum(exp(x)) + y, y >= 0; numeric_type = T)
     if test
         @test problem_vexity(p) == ConvexVexity()
     end
     handle_problem!(p)
     if test
-        @test p.optval ≈ sum(exp.([1,2,3])) atol = atol rtol = rtol
+        @test p.optval ≈ sum(exp.([1, 2, 3])) atol = atol rtol = rtol
         @test evaluate(y) ≈ 0 atol = atol
     end
 

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -22,6 +22,19 @@
         @test evaluate(exp(y)) ≈ 1 atol = atol rtol = rtol
     end
 
+    # Test for constant `exp` (#613)
+    y = Variable()
+    x = constant([1,2,3])
+    p = minimize(sum(exp(x)) + y, y >= 0; numeric_type = T)
+    if test
+        @test problem_vexity(p) == ConvexVexity()
+    end
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ sum(exp.([1,2,3])) atol = atol rtol = rtol
+        @test evaluate(y) ≈ 0 atol = atol
+    end
+
     y = Variable()
     p = minimize(exp(y), y >= 1; numeric_type = T)
 


### PR DESCRIPTION
closes #254 

Before: on the original problem, today I OOM'd on my 16 GB macbook pro. On [previous attempts](https://github.com/jump-dev/Convex.jl/issues/254#issuecomment-1636944289), I got
```julia
1303.736478 seconds (11.94 M allocations: 191.588 GiB, 92.49% gc time)
```

On this branch:
```julia
  5.474096 seconds (1.13 M allocations: 216.129 MiB, 20.82% gc time)
```

The issue is formulating 33378 IndexAtoms and so forth. In general in Convex we must never do scalar operations if we hope to formulate things performantly (unless we move everything to a scalar representation like MOI).

Here, I couldn't see how to avoid the scalar operations, so I lower to MOI to do them on that level, which is efficient.

I filed #614 to track this issue more generally.