### PR TITLE
Test conic forms for constant values

### DIFF
--- a/src/atoms/HuberAtom.jl
+++ b/src/atoms/HuberAtom.jl
@@ -28,6 +28,9 @@ curvature(::HuberAtom) = ConvexVexity()
 
 function evaluate(x::HuberAtom)
     c = evaluate(x.children[1])
+    if c isa Number
+        c = [c]
+    end
     for i in 1:length(c)
         if c[i] <= x.M
             c[i] = c[i]^2

--- a/src/real_operate.jl
+++ b/src/real_operate.jl
@@ -314,14 +314,14 @@ end
 
 # Here we have our two complex -> real functions
 # These are allowed these inputs:
-const ComplexToRealInputs2{T} =
+const ComplexToRealInputs{T} =
     Union{ComplexTape{T},SparseTape{T},ComplexStructOfVec{T},Vector{T}}
 
 # `real`
 function real_operate(
     ::typeof(real),
     ::Type{T},
-    c::ComplexToRealInputs2{T},
+    c::ComplexToRealInputs{T},
 ) where {T}
     return real(c)
 end
@@ -330,7 +330,7 @@ end
 function real_operate(
     ::typeof(imag),
     ::Type{T},
-    c::ComplexToRealInputs2{T},
+    c::ComplexToRealInputs{T},
 ) where {T}
     return imag(c)
 end

--- a/src/real_operate.jl
+++ b/src/real_operate.jl
@@ -314,14 +314,14 @@ end
 
 # Here we have our two complex -> real functions
 # These are allowed these inputs:
-const ComplexToRealInputs{T} =
-    Union{ComplexTape{T},SparseTape{T},ComplexStructOfVec{T}}
+const ComplexToRealInputs2{T} =
+    Union{ComplexTape{T},SparseTape{T},ComplexStructOfVec{T},Vector{T}}
 
 # `real`
 function real_operate(
     ::typeof(real),
     ::Type{T},
-    c::ComplexToRealInputs{T},
+    c::ComplexToRealInputs2{T},
 ) where {T}
     return real(c)
 end
@@ -330,7 +330,7 @@ end
 function real_operate(
     ::typeof(imag),
     ::Type{T},
-    c::ComplexToRealInputs{T},
+    c::ComplexToRealInputs2{T},
 ) where {T}
     return imag(c)
 end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -81,16 +81,11 @@ function solve!(
     optimizer_factory;
     silent_solver = false,
     warmstart::Bool = false,
-    context_ref = nothing,
 )
     if problem_vexity(p) in (ConcaveVexity(), NotDcp())
         throw(DCPViolationError())
     end
     context = Context(p, optimizer_factory)
-    # helper for tests, to retrieve the context
-    if context_ref !== nothing
-        context_ref[] = context
-    end
     if silent_solver
         MOI.set(context.model, MOI.Silent(), true)
     end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -81,11 +81,16 @@ function solve!(
     optimizer_factory;
     silent_solver = false,
     warmstart::Bool = false,
+    context_ref = nothing,
 )
     if problem_vexity(p) in (ConcaveVexity(), NotDcp())
         throw(DCPViolationError())
     end
     context = Context(p, optimizer_factory)
+    # helper for tests, to retrieve the context
+    if context_ref !== nothing
+        context_ref[] = context
+    end
     if silent_solver
         MOI.set(context.model, MOI.Silent(), true)
     end

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -10,7 +10,6 @@ using Test
 
 # Do not use `using LinearAlgebra` to check symbols are re-exported by Convex.
 import LinearAlgebra
-import Clarabel
 import MathOptInterface as MOI
 
 function runtests()
@@ -34,38 +33,6 @@ end
 _to_moi(x::Convex.SparseTape) = _to_moi(Convex.to_vaf(x))
 
 _to_moi(v::MOI.AbstractScalarFunction) = v
-
-# Retrieve the numeric value of the result of `conic_form!` post-solve
-_value(::Any, x) = evaluate(x)
-
-function _value(context, x::Convex.SparseTape)
-    val = [MOI.get(context.model, MOI.VariablePrimal(), i) for i in x.variables]
-    return x.operation.matrix * val + x.operation.vector
-end
-
-# Recursively manipulate an `AbstractExpr` to replace variables with constants
-function make_constant!(expr::Convex.AbstractVariable)
-    if Convex.iscomplex(expr)
-        val = rand(Float64, size(expr)) + im * rand(Float64, size(expr))
-    else
-        val = rand(Float64, size(expr))
-    end
-    if size(expr, 1) == size(expr, 2)
-        val = val' * val
-    end
-    return constant(val)
-end
-
-function make_constant!(
-    e::Union{Number,AbstractArray,Convex.Constant,Convex.ComplexConstant},
-)
-    return e
-end
-
-function make_constant!(e::Convex.AbstractExpr)
-    e.children = map(make_constant!, e.children)
-    return e
-end
 
 """
     _test_atom(build_fn::Function, target_string::String; value_type = Float64)
@@ -111,26 +78,49 @@ function _test_atom(build_fn, target_string::String; value_type = Float64)
     if Convex.vexity(atom) == Convex.ConcaveVexity()
         atom = -atom
     end
-    # Then we recursively replace variables with `constant`s
-    make_constant!(atom)
-    # For now, the complex case has too many issues to handle...
-    if !Convex.iscomplex(atom) && !any(Convex.iscomplex, atom.children)
-        t = Variable()
-        problem = minimize(t, t >= sum(atom); numeric_type = value_type)
-        c = Convex.Context(problem, Clarabel.Optimizer{value_type})
-        context_ref = Ref{Convex.Context{value_type}}()
-        Convex.solve!(
-            problem,
-            Clarabel.Optimizer;
-            silent_solver = true,
-            context_ref,
-        )
-        c = context_ref[]
-        v = _value(c, t)
-        e = evaluate(atom)
-        @test sum(e) ≈ v rtol = 1e-4 atol = 1e-4
-    end
     _test_reformulation(build_fn, target_string; value_type)
+    _test_constant_atom(build_fn; value_type)
+    return
+end
+
+# Recursively _make_constant! an `AbstractExpr` to replace variables with
+# constants
+function _to_constant(expr::Convex.AbstractVariable)
+    if Convex.iscomplex(expr)
+        val = rand(Float64, size(expr)) + im * rand(Float64, size(expr))
+    else
+        val = rand(Float64, size(expr))
+    end
+    if size(expr, 1) == size(expr, 2)
+        val = val' * val
+    end
+    return constant(val)
+end
+
+_to_constant(x::Convex.Value) = x
+_to_constant(x::Union{Convex.Constant,Convex.ComplexConstant}) = x
+
+function _to_constant(e::Convex.AbstractExpr)
+    e.children = map(_to_constant, e.children)
+    return e
+end
+
+function _test_constant_atom(build_fn; value_type)
+    context = Convex.Context{value_type}(MOI.Utilities.Model{value_type})
+    atom = _to_constant(build_fn(context))
+    if Convex.iscomplex(atom) || any(Convex.iscomplex, atom.children)
+        return
+    end
+    form = Convex.conic_form!(context, atom)
+    if !(form isa AbstractVector)
+        return  # The reformulation is still in terms of MOI variables.
+    end
+    answer = evaluate(atom)
+    if answer isa Number
+        @test only(form) ≈ answer
+    else
+        @test form ≈ vec(answer)
+    end
     return
 end
 

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -10,6 +10,7 @@ using Test
 
 # Do not use `using LinearAlgebra` to check symbols are re-exported by Convex.
 import LinearAlgebra
+
 import MathOptInterface as MOI
 
 function runtests()
@@ -72,12 +73,6 @@ function _test_atom(build_fn, target_string::String; value_type = Float64)
     N = length(atom.children)
     @test Convex.monotonicity(atom) isa NTuple{N,Convex.Monotonicity}
     @test Convex.curvature(atom) isa Convex.Vexity
-    # Now, we will test if our atom's `conic_form` and `evaluate`
-    # agree for constants (and that they are well-defined for constants).
-    # To do so, we first flip our atom to have non-concave vexity:
-    if Convex.vexity(atom) == Convex.ConcaveVexity()
-        atom = -atom
-    end
     _test_reformulation(build_fn, target_string; value_type)
     _test_constant_atom(build_fn; value_type)
     return

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -107,10 +107,10 @@ function _test_constant_atom(build_fn; value_type)
         return
     end
     form = Convex.conic_form!(context, atom)
+    answer = evaluate(atom)
     if !(form isa AbstractVector)
         return  # The reformulation is still in terms of MOI variables.
     end
-    answer = evaluate(atom)
     if answer isa Number
         @test only(form) ≈ answer
     else

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -78,8 +78,6 @@ function _test_atom(build_fn, target_string::String; value_type = Float64)
     return
 end
 
-# Recursively _make_constant! an `AbstractExpr` to replace variables with
-# constants
 function _to_constant(expr::Convex.AbstractVariable)
     if Convex.iscomplex(expr)
         val = rand(Float64, size(expr)) + im * rand(Float64, size(expr))


### PR DESCRIPTION
Addresses https://github.com/jump-dev/Convex.jl/issues/616 in the real case only. In the complex case unfortunately I found many issues, too many to address in this PR. Some would be addressed similarly to the change for `new_conic_form!(context::Context{T}, e::RelativeEntropyAtom)`, where `GenericConstraint` nicely handles the constant case, but direct `MOI_add_constraint` does not.

(The issues here are not really correctness bugs, but rather errors one would get if for some reason they had constant values rather than variables in some atoms, such as if you `fix!`'d a variable).