### PR TITLE
Improve performance of `ExpAtom`, `LogAtom`, and `EntropyAtom`

### DIFF
--- a/src/atoms/EntropyAtom.jl
+++ b/src/atoms/EntropyAtom.jl
@@ -38,11 +38,10 @@ entropy_elementwise(x::AbstractExpr) = EntropyAtom(x)
 function new_conic_form!(context::Context, e::EntropyAtom)
     # -x log x >= t  <=>  x exp(t/x) <= 1  <==>  (t,x,1) in exp cone
     x = e.children[1]
-    m, n = size(x)
-    t = Variable(m, n)
-    for i in 1:m, j in 1:n
-        f = vcat(t[i, j], x[i, j], 1)
-        add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
-    end
-    return conic_form!(context, t)
+    # to choose the permutation, we want the elements of the constraint to be
+    # (t, x, 1)
+    # but with the identity permutation, the default is
+    # (x, 1, t)
+    # So (3, 1, 2) permutes it to the correct order.
+    return vectorized_exp_cone_triples!(context, x, (3, 1, 2))
 end

--- a/src/atoms/EntropyAtom.jl
+++ b/src/atoms/EntropyAtom.jl
@@ -36,12 +36,12 @@ entropy(x::AbstractExpr) = sum(EntropyAtom(x))
 entropy_elementwise(x::AbstractExpr) = EntropyAtom(x)
 
 function new_conic_form!(context::Context, e::EntropyAtom)
-    # -x log x >= t  <=>  x exp(t/x) <= 1  <==>  (t,x,1) in exp cone
+    # -x log(x) >= t  <=>  x exp(t/x) <= 1 <=> (t, x, 1) in ExponentialCone()
     x = e.children[1]
-    # to choose the permutation, we want the elements of the constraint to be
-    # (t, x, 1)
-    # but with the identity permutation, the default is
-    # (x, 1, t)
-    # So (3, 1, 2) permutes it to the correct order.
-    return vectorized_exp_cone_triples!(context, x, (3, 1, 2))
+    # To choose the permutation, we want the elements of the constraint to be
+    #   (t, x, 1) in ExponentialCone()
+    # but with the identity permutation, the default is:
+    #   (x, 1, t) in ExponentialCone()
+    # so [3, 1, 2] permutes it to the correct order.
+    return _add_vectorized_exp_cone(context, x, [3, 1, 2])
 end

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -45,10 +45,10 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
     # First, we will get `x` as an MOI.VectorAffineFunction
     x_tape = conic_form!(context, x)
-    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `Vector{T}` or `SparseTape{T}`.
-    # The `Vector{T}` case happens when `x` is a constant (or a function of a constant).
+    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `SPARSE_VECTOR{T}` or `SparseTape{T}`.
+    # The `SPARSE_VECTOR{T}` case happens when `x` is a constant (or a function of a constant).
     # In this case, we can just take `exp` directly.
-    if x_tape isa Vector
+    if x_tape isa SPARSE_VECTOR
         return exp.(x_tape)
     end
     vaf = to_vaf(x_tape)

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -36,8 +36,8 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     z = Variable(m, n)
     # Naive implementation:
     # for i in 1:m, j in 1:n
-    # f = vcat(x[i, j], 1, z[i, j])
-        # add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    #     f = vcat(x[i, j], 1, z[i, j])
+    #     add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
     # end
     # return conic_form!(context, z)
     # This is slow, since we are indexing on the Convex side, and convex is based around
@@ -59,7 +59,7 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
         # So we can't use `MOI.Utilities.vectorize`. Instead, we will construct a VectorAffineFunction manually.
         # First, we construct the VectorAffineTerm's for the first and third components.
         terms = [
-            [MOI.VectorAffineTerm(Int64(1), sat) for sat in xs[i].terms];
+            [MOI.VectorAffineTerm(Int64(1), sat) for sat in xs[i].terms]
             MOI.VectorAffineTerm(Int64(3), MOI.ScalarAffineTerm(T(1), zs[i]))
         ]
         # Then we can add in the constants, and we are good to go.

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -53,7 +53,7 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
 
     z_tape = conic_form!(context, z)
 
-    xs = MOI.Utilities.scalarize(to_vaf(x + tapi))
+    xs = MOI.Utilities.scalarize(to_vaf(x_tape))
     # Now we have a vector of `m*n` ScalarAffineFunctions in order.
 
     # We just created `z`, so we know the operation is trivial.

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -34,9 +34,37 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     x = e.children[1]
     m, n = size(x)
     z = Variable(m, n)
-    for i in 1:m, j in 1:n
-        f = vcat(x[i, j], 1, z[i, j])
-        add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    # Naive implementation:
+    # for i in 1:m, j in 1:n
+    # f = vcat(x[i, j], 1, z[i, j])
+        # add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    # end
+    # return conic_form!(context, z)
+    # This is slow, since we are indexing on the Convex side, and convex is based around
+    # vector/matrix operations. We don't want to produce n*m IndexAtoms!
+    # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
+    # First, we will get `x` as an MOI.VectorAffineFunction
+    x_tape = conic_form!(context, x)
+    vaf = to_vaf(x_tape)
+    # Next, we can extract the individual components of `x` via `MOI.Utilities.scalarize`
+    xs = MOI.Utilities.scalarize(vaf)
+    # Now we have a vector of `m*n` ScalarAffineFunctions in order.
+    # We can likewise lower `z` to a vector of `MOI.VariableIndex`
+    z_tape = conic_form!(context, z)
+    zs = z_tape.variables
+    for i in eachindex(xs, zs)
+        # Now, we wish to add the constraint `(x[i], 1, z[i]) ∈ MOI.ExponentialCone()`
+        # however, we have 3 different types: x[i] is a ScalarAffineFunction, 1 is a constant,
+        # and `z` is a VariableIndex.
+        # So we can't use `MOI.Utilities.vectorize`. Instead, we will construct a VectorAffineFunction manually.
+        # First, we construct the VectorAffineTerm's for the first and third components.
+        terms = [
+            [MOI.VectorAffineTerm(Int64(1), sat) for sat in xs[i].terms];
+            MOI.VectorAffineTerm(Int64(3), MOI.ScalarAffineTerm(T(1), zs[i]))
+        ]
+        # Then we can add in the constants, and we are good to go.
+        vaf_i = MOI.VectorAffineFunction(terms, [xs[i].constant, T(1), T(0)])
+        MOI.add_constraint(context.model, vaf_i, MOI.ExponentialCone())
     end
-    return conic_form!(context, z)
+    return z_tape
 end

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -45,6 +45,12 @@ function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
     # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
     # First, we will get `x` as an MOI.VectorAffineFunction
     x_tape = conic_form!(context, x)
+    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `Vector{T}` or `SparseTape{T}`.
+    # The `Vector{T}` case happens when `x` is a constant (or a function of a constant).
+    # In this case, we can just take `exp` directly.
+    if x_tape isa Vector
+        return exp.(x_tape)
+    end
     vaf = to_vaf(x_tape)
     # Next, we can extract the individual components of `x` via `MOI.Utilities.scalarize`
     xs = MOI.Utilities.scalarize(vaf)

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -30,42 +30,53 @@ evaluate(x::ExpAtom) = exp.(evaluate(x.children[1]))
 Base.exp(x::AbstractExpr) = ExpAtom(x)
 
 function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
-    # exp(x) \leq z  <=>  (x,1,z) \in ExpCone
+    # exp(x) \leq t  <=>  (x,1,t) \in ExpCone
     x = e.children[1]
-    m, n = size(x)
-    z = Variable(m, n)
-    # Naive implementation:
-    # for i in 1:m, j in 1:n
-    #     f = vcat(x[i, j], 1, z[i, j])
-    #     add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
-    # end
-    # return conic_form!(context, z)
-    # This is slow, since we are indexing on the Convex side, and convex is based around
-    # vector/matrix operations. We don't want to produce n*m IndexAtoms!
-    # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
     x_tape = conic_form!(context, x)
-    # since `ExpAtom` is restricted to `sign(x)` being real, `x_tape` is either `SPARSE_VECTOR{T}` or `SparseTape{T}`.
-    # The `SPARSE_VECTOR{T}` case happens when `x` is a constant (or a function of a constant).
-    # In this case, we can just take `exp` directly.
     if x_tape isa SPARSE_VECTOR
         return exp.(x_tape)
     end
+    return vectorized_exp_cone_triples!(context, x)
+end
 
-    z_tape = conic_form!(context, z)
+# constrains `(x[i], 1, t[i]) ∈ ExponentialCone` for each element of `x` and returns `t`. Optionally pass a permutation to reorder the triple before it is constrained.
+function vectorized_exp_cone_triples!(
+    context::Context{T},
+    x,
+    permutation = (1, 2, 3),
+) where {T}
+    @assert issetequal(permutation, (1, 2, 3))
+    @assert length(permutation) == 3
+    m, n = size(x)
+    t = Variable(m, n)
+    # Naive implementation:
+    # t = Variable(m, n)
+    # for i in 1:m, j in 1:n
+    #     f = vcat(x[i, j], 1, t[i, j]) # up to permutation
+    #     add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    # end
+    # return conic_form!(context, t)
+    # This is slow, since we are indexing on the Convex side, and convex is based around
+    # vector/matrix operations. We don't want to produce n*m IndexAtoms!
+    # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
+    t_tape = conic_form!(context, t)
+    # We just created `t`, so we know its "operation" is trivial.
+    # Therefore we can just take the variables to get a vector of `MOI.VariableIndex`
+    ts = t_tape.variables
 
+    x_tape = conic_form!(context, x)
     xs = MOI.Utilities.scalarize(to_vaf(x_tape))
     # Now we have a vector of `m*n` ScalarAffineFunctions in order.
 
-    # We just created `z`, so we know the operation is trivial.
-    # Therefore we can just take the variables to get a vector of `MOI.VariableIndex`
-    zs = z_tape.variables
     # now we simply add the constraints
-    for (xi, zi) in zip(xs, zs)
+    for (xi, ti) in zip(xs, ts)
+        tuple = (xi, T(1), ti)
+        ordered_tuple = ntuple(i -> tuple[permutation[i]], Val(3))
         MOI.add_constraint(
             context.model,
-            MOI.Utilities.operate(vcat, T, xi, T(1), zi),
+            MOI.Utilities.operate(vcat, T, ordered_tuple...),
             MOI.ExponentialCone(),
         )
     end
-    return z_tape
+    return t_tape
 end

--- a/src/atoms/ExpAtom.jl
+++ b/src/atoms/ExpAtom.jl
@@ -30,51 +30,65 @@ evaluate(x::ExpAtom) = exp.(evaluate(x.children[1]))
 Base.exp(x::AbstractExpr) = ExpAtom(x)
 
 function new_conic_form!(context::Context{T}, e::ExpAtom) where {T}
-    # exp(x) \leq t  <=>  (x,1,t) \in ExpCone
+    # exp(x) <= t  <=>  (x, 1, t) in ExponentialCone()
     x = e.children[1]
     x_tape = conic_form!(context, x)
     if x_tape isa SPARSE_VECTOR
         return exp.(x_tape)
     end
-    return vectorized_exp_cone_triples!(context, x)
+    return _add_vectorized_exp_cone(context, x, [1, 2, 3])
 end
 
-# constrains `(x[i], 1, t[i]) ∈ ExponentialCone` for each element of `x` and returns `t`. Optionally pass a permutation to reorder the triple before it is constrained.
-function vectorized_exp_cone_triples!(
+"""
+    _add_vectorized_exp_cone(
+        context::Context{T},
+        x,
+        permutation::Vector{Int},
+    ) where {T}
+
+Constrains `(x[i], 1, t[i]) ∈ ExponentialCone()` for each element of `x` and
+returns `t`.
+
+Permutation is a permuted vector of `[1, 2, 3]` to reorder the triple before it
+is constrained. This is helpful for `LogAtom` and `EntropyAtom`.
+
+## Motivation
+
+A naive implementation of this method is:
+```julia
+    m, n = size(x)
+    t = Variable(m, n)
+    for i in 1:m, j in 1:n
+        f = vcat(x[i, j], 1, t[i, j])[collect(permutation)]
+        add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
+    end
+    return conic_form!(context, t)
+end
+```
+This is slow because we are indexing on the Convex side, and Convex is based
+around vector/matrix operations. We don't want to produce n*m IndexAtoms!
+
+Instead, we will drop to the MOI level to implement this in terms of scalar
+operations.
+"""
+function _add_vectorized_exp_cone(
     context::Context{T},
     x,
-    permutation = (1, 2, 3),
+    permutation::Vector{Int},
 ) where {T}
     @assert issetequal(permutation, (1, 2, 3))
     @assert length(permutation) == 3
     m, n = size(x)
     t = Variable(m, n)
-    # Naive implementation:
-    # t = Variable(m, n)
-    # for i in 1:m, j in 1:n
-    #     f = vcat(x[i, j], 1, t[i, j]) # up to permutation
-    #     add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
-    # end
-    # return conic_form!(context, t)
-    # This is slow, since we are indexing on the Convex side, and convex is based around
-    # vector/matrix operations. We don't want to produce n*m IndexAtoms!
-    # Instead, we will drop to the MOI level to implement this in terms of scalar operations.
     t_tape = conic_form!(context, t)
-    # We just created `t`, so we know its "operation" is trivial.
-    # Therefore we can just take the variables to get a vector of `MOI.VariableIndex`
-    ts = t_tape.variables
-
+    ts = t_tape.variables::Vector{MOI.VariableIndex}
     x_tape = conic_form!(context, x)
     xs = MOI.Utilities.scalarize(to_vaf(x_tape))
-    # Now we have a vector of `m*n` ScalarAffineFunctions in order.
-
-    # now we simply add the constraints
     for (xi, ti) in zip(xs, ts)
-        tuple = (xi, T(1), ti)
-        ordered_tuple = ntuple(i -> tuple[permutation[i]], Val(3))
+        args = (xi, T(1), ti)[permutation]
         MOI.add_constraint(
             context.model,
-            MOI.Utilities.operate(vcat, T, ordered_tuple...),
+            MOI.Utilities.operate(vcat, T, args...),
             MOI.ExponentialCone(),
         )
     end

--- a/src/atoms/LogAtom.jl
+++ b/src/atoms/LogAtom.jl
@@ -30,13 +30,12 @@ evaluate(x::LogAtom) = log.(evaluate(x.children[1]))
 Base.log(x::AbstractExpr) = LogAtom(x)
 
 function new_conic_form!(context::Context, e::LogAtom)
-    # log(x) \geq t  <=> (t,1,x) \in ExpCone
+    # log(x) >= t  <=> (t, 1, x) in ExponentialCone()
     x = e.children[1]
-
-    # to choose the permutation, we want the elements of the constraint to be
-    # (t, 1, x)
-    # but with the identity permutation, the default is
-    # (x, 1, t)
-    # So (3, 2, 1) permutes it to the correct order.
-    return vectorized_exp_cone_triples!(context, x, (3, 2, 1))
+    # To choose the permutation, we want the elements of the constraint to be:
+    #   (t, 1, x) in ExponentialCone()
+    # The default is:
+    #   (x, 1, t) in ExponentialCone()
+    # so [3, 2, 1] permutes it to the correct order.
+    return _add_vectorized_exp_cone(context, x, [3, 2, 1])
 end

--- a/src/atoms/LogAtom.jl
+++ b/src/atoms/LogAtom.jl
@@ -30,13 +30,13 @@ evaluate(x::LogAtom) = log.(evaluate(x.children[1]))
 Base.log(x::AbstractExpr) = LogAtom(x)
 
 function new_conic_form!(context::Context, e::LogAtom)
-    # log(z) \geq x  <=> (x,1,z) \in ExpCone
-    z = e.children[1]
-    m, n = size(z)
-    x = Variable(m, n)
-    for i in 1:m, j in 1:n
-        f = vcat(x[i, j], 1, z[i, j])
-        add_constraint!(context, GenericConstraint{MOI.ExponentialCone}(f))
-    end
-    return conic_form!(context, x)
+    # log(x) \geq t  <=> (t,1,x) \in ExpCone
+    x = e.children[1]
+
+    # to choose the permutation, we want the elements of the constraint to be
+    # (t, 1, x)
+    # but with the identity permutation, the default is
+    # (x, 1, t)
+    # So (3, 2, 1) permutes it to the correct order.
+    return vectorized_exp_cone_triples!(context, x, (3, 2, 1))
 end

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -24,14 +24,14 @@
 
     # Test for constant `exp` (#613)
     y = Variable()
-    x = constant([1,2,3])
+    x = constant([1, 2, 3])
     p = minimize(sum(exp(x)) + y, y >= 0; numeric_type = T)
     if test
         @test problem_vexity(p) == ConvexVexity()
     end
     handle_problem!(p)
     if test
-        @test p.optval ≈ sum(exp.([1,2,3])) atol = atol rtol = rtol
+        @test p.optval ≈ sum(exp.([1, 2, 3])) atol = atol rtol = rtol
         @test evaluate(y) ≈ 0 atol = atol
     end
 

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -22,6 +22,19 @@
         @test evaluate(exp(y)) ≈ 1 atol = atol rtol = rtol
     end
 
+    # Test for constant `exp` (#613)
+    y = Variable()
+    x = constant([1,2,3])
+    p = minimize(sum(exp(x)) + y, y >= 0; numeric_type = T)
+    if test
+        @test problem_vexity(p) == ConvexVexity()
+    end
+    handle_problem!(p)
+    if test
+        @test p.optval ≈ sum(exp.([1,2,3])) atol = atol rtol = rtol
+        @test evaluate(y) ≈ 0 atol = atol
+    end
+
     y = Variable()
     p = minimize(exp(y), y >= 1; numeric_type = T)
 


### PR DESCRIPTION
Generalizes #613 to the other atoms that uses exponential cone constraints in the same way.

closes #613 
closes #254 

addresses the first three items of #614