### PR TITLE
Add default fallbacks for head and vexity with MOI sets

### DIFF
--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -50,15 +50,38 @@ end
 
 vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 
-# The default vexity for MOI sets is assumed to required affine functions and be
-# convex. This is for the most common case of the conic sets. There might be
-# some incorrect answers, like if the user adds something like the `MOI.SOS1` or
-# `MOI.Complements`, but this shouldn't really be relevant for Convex.jl?
-function vexity(vex, ::Union{MOI.PositiveSemidefiniteConeSquare,MOI.ExponentialCone,MOI.SecondOrderCone,MOI.RotatedSecondOrderCone,MOI.RelativeEntropyCone})
+function vexity(
+    vex, 
+    # An enumeration of sets that are most likely to be used by Convex.jl
+    ::Union{
+        MOI.SecondOrderCone,
+        MOI.RotatedSecondOrderCone,
+        MOI.ExponentialCone,
+        MOI.DualExponentialCone,
+        MOI.PowerCone,
+        MOI.DualPowerCone,
+        MOI.PositiveSemidefiniteConeSquare,
+        MOI.GeometricMeanCone,
+        MOI.NormCone,
+        MOI.NormInfinityCone,
+        MOI.NormOneCone,
+        MOI.NormSpectralCone,
+        MOI.NormNuclearCone,
+        MOI.RelativeEntropyCone,
+        MOI.LogDetConeSquare,
+        MOI.RootDetConeSquare,
+    },
+)
     if !(vex == ConstVexity() || vex == AffineVexity())
         return NotDcp()
     end
     return ConvexVexity()
+end
+
+function vexity(::Any, set::MOI.AbstractSet)
+    return error(
+        "`Convex.vexity(vex, ::$(typeof(set)))`: is not yet implemented. Please open an issue at https://github.com/jump-dev/Convex.jl",
+    ) 
 end
 
 function _add_constraint!(context::Context, c::GenericConstraint)

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -51,7 +51,7 @@ end
 vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 
 function vexity(
-    vex, 
+    vex,
     # An enumeration of sets that are most likely to be used by Convex.jl
     ::Union{
         MOI.SecondOrderCone,
@@ -81,7 +81,7 @@ end
 function vexity(::Any, set::MOI.AbstractSet)
     return error(
         "`Convex.vexity(vex, ::$(typeof(set)))`: is not yet implemented. Please open an issue at https://github.com/jump-dev/Convex.jl",
-    ) 
+    )
 end
 
 function _add_constraint!(context::Context, c::GenericConstraint)

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -51,10 +51,10 @@ end
 vexity(c::GenericConstraint) = vexity(vexity(c.child), c.set)
 
 # The default vexity for MOI sets is assumed to required affine functions and be
-# convex. This is for the most common case of the connic sets. There might be
+# convex. This is for the most common case of the conic sets. There might be
 # some incorrect answers, like if the user adds something like the `MOI.SOS1` or
 # `MOI.Complements`, but this shouldn't really be relevant for Convex.jl?
-function vexity(vex, ::MOI.AbstractSet)
+function vexity(vex, ::Union{MOI.PositiveSemidefiniteConeSquare,MOI.ExponentialCone,MOI.SecondOrderCone,MOI.RotatedSecondOrderCone,MOI.RelativeEntropyCone})
     if !(vex == ConstVexity() || vex == AffineVexity())
         return NotDcp()
     end

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -220,7 +220,7 @@ function test_GenericConstraint_SecondOrderCone()
     @test isapprox(c.dual, [1, -2 / t_, -3 / t_, -4 / t_]; atol = 1e-3)
     c = Convex.GenericConstraint{MOI.SecondOrderCone}(vcat(square(t), x))
     @test vexity(c) === Convex.NotDcp()
-    @test Convex.sprint(Convex.head, c) == "soc"
+    @test Convex.sprint(Convex.head, c) == "MOI.SecondOrderCone"
     return
 end
 
@@ -251,7 +251,7 @@ function test_GenericConstraint_RotatedSecondOrderCone()
     @test isapprox(c.dual, [1, 29 / 2, -2, -3, -4]; atol = 1e-3)
     c = Convex.GenericConstraint{MOI.RotatedSecondOrderCone}(vcat(square(t), x))
     @test vexity(c) === Convex.NotDcp()
-    @test Convex.sprint(Convex.head, c) == "rsoc"
+    @test Convex.sprint(Convex.head, c) == "MOI.RotatedSecondOrderCone"
     return
 end
 
@@ -275,7 +275,7 @@ function test_GenericConstraint_ExponentialConeConstraint()
     @test isapprox(c.dual, [-exp(3 / 2), exp(3 / 2) / 2, 1]; atol = 1e-4)
     c = Convex.GenericConstraint{MOI.ExponentialCone}(vcat(square(z), 1, z))
     @test vexity(c) === Convex.NotDcp()
-    @test sprint(Convex.head, c) == "exp"
+    @test sprint(Convex.head, c) == "MOI.ExponentialCone"
     return
 end
 
@@ -293,7 +293,7 @@ function test_GenericConstraint_RelativeEntropyConeConstraint()
     @test isapprox(c.dual, [1, 2, 1, -log(2) - 1, -1]; atol = 1e-3)
     c = Convex.GenericConstraint{MOI.RelativeEntropyCone}(vcat(square(u), 1, u))
     @test vexity(c) === Convex.NotDcp()
-    @test sprint(Convex.head, c) == "RelativeEntropyCone"
+    @test sprint(Convex.head, c) == "MOI.RelativeEntropyCone"
     return
 end
 

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -297,6 +297,18 @@ function test_GenericConstraint_RelativeEntropyConeConstraint()
     return
 end
 
+function test_GenericConstraint_NoVexity()
+    x = Variable(2)
+    set = MOI.Complements(2)
+    @test_throws(
+        ErrorException(
+            "`Convex.vexity(vex, ::$(typeof(set)))`: is not yet implemented. Please open an issue at https://github.com/jump-dev/Convex.jl",
+        ),
+        vexity(Convex.GenericConstraint(x, set)),
+    )
+    return
+end
+
 end  # TestConstraints
 
 TestConstraints.runtests()


### PR DESCRIPTION
Closes #630

One possible solution to discuss.

 * The `head` method is reasonable.
 * The `vexity` method is up for debate. There are arguments for and against.