### PR TITLE
improve performance of `conv`

### DIFF
--- a/src/reformulations/conv.jl
+++ b/src/reformulations/conv.jl
@@ -11,8 +11,6 @@ then we have `A * x ≈ conv1d(h, x)`.
 """
 function conv1D_matrix(h::AbstractVector, n::Integer)
     m = length(h)
-    # It is much more efficient to construct sparse matrices
-    # this way rather than starting from `spzeros` and indexing into it.
     Is = Int[]
     Js = Int[]
     Vs = eltype(h)[]

--- a/src/reformulations/conv.jl
+++ b/src/reformulations/conv.jl
@@ -3,15 +3,36 @@
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file or at https://opensource.org/license/bsd-2-clause
 
+"""
+    conv1D_matrix(h::AbstractVector, n::Integer) -> SparseMatrixCSC
+
+Create a sparse matrix `A` such that if `x` has length `n`,
+then we have `A * x ≈ conv1d(h, x)`.
+"""
+function conv1D_matrix(h::AbstractVector, n::Integer)
+    m = length(h)
+    # It is much more efficient to construct sparse matrices
+    # this way rather than starting from `spzeros` and indexing into it.
+    Is = Int[]
+    Js = Int[]
+    Vs = eltype(h)[]
+    # build matrix by columns
+    for j in 1:n
+        append!(Is, j:(j+m-1))
+        append!(Js, repeat([j], m))
+        append!(Vs, h)
+    end
+    return SparseArrays.sparse(Is, Js, Vs, m + n - 1, n)
+end
+
 function conv(x::Value, y::AbstractExpr)
     if length(x) != size(x, 1) || size(y, 2) > 1
         error("convolution only supported between two vectors")
     end
-    m, n = length(x), size(y, 1)
-    X = spzeros(eltype(x), m + n - 1, n)
-    for i in 1:n, j in 1:m
-        X[i+j-1, i] = x[j]
-    end
+    length(x) > 0 ||
+        throw(ArgumentError("convolution with empty vector not supported"))
+
+    X = conv1D_matrix(x, length(y))
     return X * y
 end
 

--- a/src/reformulations/conv.jl
+++ b/src/reformulations/conv.jl
@@ -14,9 +14,9 @@ function conv1D_matrix(h::AbstractVector, n::Integer)
     Is = Int[]
     Js = Int[]
     Vs = eltype(h)[]
-    sizehint!(Is, n*m)
-    sizehint!(Js, n*m)
-    sizehint!(Vs, n*m)
+    sizehint!(Is, n * m)
+    sizehint!(Js, n * m)
+    sizehint!(Vs, n * m)
     # build matrix by columns
     for j in 1:n
         append!(Is, j:(j+m-1))

--- a/src/reformulations/conv.jl
+++ b/src/reformulations/conv.jl
@@ -16,10 +16,13 @@ function conv1D_matrix(h::AbstractVector, n::Integer)
     Is = Int[]
     Js = Int[]
     Vs = eltype(h)[]
+    sizehint!(Is, n*m)
+    sizehint!(Js, n*m)
+    sizehint!(Vs, n*m)
     # build matrix by columns
     for j in 1:n
         append!(Is, j:(j+m-1))
-        append!(Js, repeat([j], m))
+        append!(Js, (j for _ in 1:m))
         append!(Vs, h)
     end
     return SparseArrays.sparse(Is, Js, Vs, m + n - 1, n)

--- a/src/reformulations/conv.jl
+++ b/src/reformulations/conv.jl
@@ -30,9 +30,9 @@ function conv(x::Value, y::AbstractExpr)
     if length(x) != size(x, 1) || size(y, 2) > 1
         error("convolution only supported between two vectors")
     end
-    length(x) > 0 ||
+    if length(x) == 0
         throw(ArgumentError("convolution with empty vector not supported"))
-
+    end
     X = conv1D_matrix(x, length(y))
     return X * y
 end

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -1968,6 +1968,11 @@ function test_conv()
         ErrorException("convolution only supported between two vectors"),
         conv([1, 2], Variable(2, 2)),
     )
+    @test_throws(
+        ArgumentError("convolution with empty vector not supported"),
+        conv([], Variable(2)),
+    )
+
     return
 end
 

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -1972,7 +1972,6 @@ function test_conv()
         ArgumentError("convolution with empty vector not supported"),
         conv([], Variable(2)),
     )
-
     return
 end
 

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -687,6 +687,7 @@ function test_conv1D_matrix()
             @test Convex.conv1D_matrix(x, length(y)) * y ≈ _conv(x, y)
         end
     end
+    return
 end
 
 function test_conj_issue_416()


### PR DESCRIPTION
```julia
julia> using Convex, BenchmarkTools

julia> x = rand(100_000);

julia> y = Variable(200);

julia> @btime conv($x, $y)
```

gives:
```
  1.286 s (56 allocations: 1.04 GiB) # master
  562.229 ms (37 allocations: 1.64 GiB) # PR
```

So 2x speed, but 1.6x allocations. I think it's a win overall, though not huge. Aimed at https://github.com/jump-dev/Convex.jl/issues/376