### PR TITLE
Add Aqua.jl to the tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
 ECOS = "e2685f51-7e38-5353-a97d-a921fd2c8199"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,9 +18,9 @@ Random.seed!(2)
 end
 
 @testset "Aqua" begin
-    Aqua.test_all(Convex; ambiguities=false, piracies=false)
+    Aqua.test_all(Convex; ambiguities = false, piracies = false)
     # Convex currently has some light piracy of `hcat`, `vcat` and `hvcat`
-    Aqua.test_piracies(Convex; treat_as_own=[hcat, vcat, hvcat])
+    Aqua.test_piracies(Convex; treat_as_own = [hcat, vcat, hvcat])
     # Convex currently has some ambiguities
-    Aqua.test_ambiguities(Convex; broken=true)
+    Aqua.test_ambiguities(Convex; broken = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file or at https://opensource.org/license/bsd-2-clause
 
-using Test
+using Test, Aqua, Convex
 
 # Seed random number stream to improve test reliability
 import Random
@@ -15,4 +15,12 @@ Random.seed!(2)
     include("test_constraints.jl")
     include("test_problem_depot.jl")
     include("MOI_wrapper.jl")
+end
+
+@testset "Aqua" begin
+    Aqua.test_all(Convex; ambiguities=false, piracies=false)
+    # Convex currently has some light piracy of `hcat`, `vcat` and `hvcat`
+    Aqua.test_piracies(Convex; treat_as_own=[hcat, vcat, hvcat])
+    # Convex currently has some ambiguities
+    Aqua.test_ambiguities(Convex; broken=true)
 end


### PR DESCRIPTION
closes #639 

This revealed 6 ambiguities:
```julia
julia> Aqua.test_ambiguities(Convex)
6 ambiguities found. To get a list, set `broken = false`.
Ambiguity #1
Convex.Problem{T}(head::Symbol, objective::Union{Nothing, Convex.AbstractExpr}) where T<:Real @ Convex ~/Convex.jl/src/problems.jl:12
Convex.Problem{T}(head::Symbol, objective::Convex.AbstractExpr, constraints::Convex.Constraint...) where T<:Real @ Convex ~/Convex.jl/src/problems.jl:186

Possible fix, define
  Convex.Problem{T}(::Symbol, ::Convex.AbstractExpr) where T<:Real

Ambiguity #2
getindex(x::Convex.AbstractExpr, I::AbstractVector{Bool}) @ Convex ~/Convex.jl/src/atoms/IndexAtom.jl:116
getindex(x::Convex.VcatAtom, inds::AbstractVector{<:Real}) @ Convex ~/Convex.jl/src/atoms/VcatAtom.jl:103

Possible fix, define
  getindex(::Convex.VcatAtom, ::AbstractVector{Bool})

Ambiguity #3
is_feasible(x::Number, set::MathOptInterface.AbstractVectorSet, tol) @ Convex ~/Convex.jl/src/constraints/GenericConstraint.jl:47
is_feasible(x, ::MathOptInterface.PositiveSemidefiniteConeSquare, tol) @ Convex ~/Convex.jl/src/constraints/GenericConstraint.jl:244

Possible fix, define
  is_feasible(::Number, ::MathOptInterface.PositiveSemidefiniteConeSquare, ::Any)

Ambiguity #4
populate_dual!(model::MathOptInterface.ModelLike, c::Convex.GenericConstraint, indices) @ Convex ~/Convex.jl/src/constraints/GenericConstraint.jl:99
populate_dual!(::MathOptInterface.ModelLike, c::Convex.Constraint, ::Nothing) @ Convex ~/Convex.jl/src/solution.jl:142

Possible fix, define
  populate_dual!(::MathOptInterface.ModelLike, ::Convex.GenericConstraint, ::Nothing)

Ambiguity #5
quadform(x::Convex.Constant, A::Convex.AbstractExpr; assume_psd) @ Convex ~/Convex.jl/src/reformulations/quadform.jl:88
quadform(x::Convex.AbstractExpr, A::Convex.Constant; assume_psd) @ Convex ~/Convex.jl/src/reformulations/quadform.jl:92

Possible fix, define
  quadform(::Convex.Constant, ::Convex.Constant)

Ambiguity #6
kwcall(::NamedTuple, ::typeof(Convex.quadform), x::Convex.Constant, A::Convex.AbstractExpr) @ Convex ~/Convex.jl/src/reformulations/quadform.jl:88
kwcall(::NamedTuple, ::typeof(Convex.quadform), x::Convex.AbstractExpr, A::Convex.Constant) @ Convex ~/Convex.jl/src/reformulations/quadform.jl:92

Possible fix, define
  kwcall(::NamedTuple, ::typeof(Convex.quadform), ::Convex.Constant, ::Convex.Constant)
```

Here I just add `broken=true`, but ideally we could pare down the list.