### PR TITLE
Add counts to problem printing

### DIFF
--- a/benchmark/254.jl
+++ b/benchmark/254.jl
@@ -27,3 +27,33 @@ let
 
     @time context = Convex.Context(problem, MOI.Utilities.Model{Float64})
 end
+
+model = problem.model
+
+function get_info(model)
+    n_constraints = 0
+    n_elements = 0
+    n_variables = MOI.get(model, MOI.NumberOfVariables())
+    n_constants = 0
+    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+        n_constraints += MOI.get(problem.model, MOI.NumberOfConstraints{F,S}())
+
+        for inds in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+            set = MOI.get(model, MOI.ConstraintSet(), inds)
+            n_elements += MOI.dimension(set)
+            f = MOI.get(model, MOI.ConstraintFunction(), inds)
+            n_constants += count_size(f)
+        end
+    end
+    return (; n_variables, n_constraints, n_elements, n_constants)
+end
+
+function count_size(f::MOI.VectorAffineFunction)
+    return length(f.terms) + length(f.constants)
+end
+
+function count_size(x)
+    @show typeof(x)
+    @show propertynames(x)
+    return 0
+end

--- a/benchmark/254.jl
+++ b/benchmark/254.jl
@@ -27,33 +27,3 @@ let
 
     @time context = Convex.Context(problem, MOI.Utilities.Model{Float64})
 end
-
-model = problem.model
-
-function get_info(model)
-    n_constraints = 0
-    n_elements = 0
-    n_variables = MOI.get(model, MOI.NumberOfVariables())
-    n_constants = 0
-    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
-        n_constraints += MOI.get(problem.model, MOI.NumberOfConstraints{F,S}())
-
-        for inds in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            set = MOI.get(model, MOI.ConstraintSet(), inds)
-            n_elements += MOI.dimension(set)
-            f = MOI.get(model, MOI.ConstraintFunction(), inds)
-            n_constants += count_size(f)
-        end
-    end
-    return (; n_variables, n_constraints, n_elements, n_constants)
-end
-
-function count_size(f::MOI.VectorAffineFunction)
-    return length(f.terms) + length(f.constants)
-end
-
-function count_size(x)
-    @show typeof(x)
-    @show propertynames(x)
-    return 0
-end

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -249,6 +249,7 @@ end
 include("utilities/tree_print.jl")
 include("utilities/tree_interface.jl")
 include("utilities/show.jl")
+include("utilities/moi_utilities.jl")
 include("utilities/iteration.jl")
 include("problem_depot/problem_depot.jl")
 

--- a/src/constraints/GeometricMeanHypoCone.jl
+++ b/src/constraints/GeometricMeanHypoCone.jl
@@ -128,7 +128,7 @@ function AbstractTrees.children(constraint::GeometricMeanHypoConeConstraint)
         constraint.T,
         constraint.cone.A,
         constraint.cone.B,
-        "t=$(constraint.cone.t)",
+        constraint.cone.t,
     )
 end
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -299,6 +299,10 @@ Base.:+(x::Array{<:Constraint}, y::Constraint) = vcat(x, y)
 
 iscomplex(c::Constraint) = iscomplex(c.lhs) || iscomplex(c.rhs)
 iscomplex(c::GenericConstraint) = iscomplex(c.child)
+iscomplex(c::RelativeEntropyEpiConeConstraint) = iscomplex(c.τ) || iscomplex(c.cone)
+iscomplex(c::RelativeEntropyEpiCone) = iscomplex(c.X) || iscomplex(c.Y)
+iscomplex(c::GeometricMeanHypoConeConstraint) = iscomplex(c.T) || iscomplex(c.cone)
+iscomplex(c::GeometricMeanHypoCone) = iscomplex(c.A) || iscomplex(c.B)
 
 function add_constraint!(context::Context, c::Constraint)
     if c in keys(context.constr_to_moi_inds)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -300,9 +300,13 @@ Base.:+(x::Array{<:Constraint}, y::Constraint) = vcat(x, y)
 
 iscomplex(c::Constraint) = iscomplex(c.lhs) || iscomplex(c.rhs)
 iscomplex(c::GenericConstraint) = iscomplex(c.child)
-iscomplex(c::RelativeEntropyEpiConeConstraint) = iscomplex(c.τ) || iscomplex(c.cone)
+function iscomplex(c::RelativeEntropyEpiConeConstraint)
+    return iscomplex(c.τ) || iscomplex(c.cone)
+end
 iscomplex(c::RelativeEntropyEpiCone) = iscomplex(c.X) || iscomplex(c.Y)
-iscomplex(c::GeometricMeanHypoConeConstraint) = iscomplex(c.T) || iscomplex(c.cone)
+function iscomplex(c::GeometricMeanHypoConeConstraint)
+    return iscomplex(c.T) || iscomplex(c.cone)
+end
 iscomplex(c::GeometricMeanHypoCone) = iscomplex(c.A) || iscomplex(c.B)
 
 function add_constraint!(context::Context, c::Constraint)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -298,6 +298,7 @@ Base.:+(x::Constraint, y::Array{<:Constraint}) = vcat(x, y)
 Base.:+(x::Array{<:Constraint}, y::Constraint) = vcat(x, y)
 
 iscomplex(c::Constraint) = iscomplex(c.lhs) || iscomplex(c.rhs)
+iscomplex(c::GenericConstraint) = iscomplex(c.child)
 
 function add_constraint!(context::Context, c::Constraint)
     if c in keys(context.constr_to_moi_inds)

--- a/src/utilities/moi_utilities.jl
+++ b/src/utilities/moi_utilities.jl
@@ -21,21 +21,9 @@ function get_counts(model)
     return (; n_variables, n_constraints, total_len_constraints, n_constants)
 end
 
+# If we use other MOI functions, we will need to add methods.
 function count_size(f::MOI.VectorAffineFunction)
     return length(f.terms) + length(f.constants)
-end
-
-function count_size(x)
-    error("Unknown:
-
-    $x
-
-    $(typeof(x))
-
-    $(propertynames(x))")
-    @show typeof(x)
-    @show propertynames(x)
-    return 0
 end
 
 function show_moi_counts(io::IO, model)

--- a/src/utilities/moi_utilities.jl
+++ b/src/utilities/moi_utilities.jl
@@ -1,0 +1,70 @@
+# Copyright (c) 2014: Madeleine Udell and contributors
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE file or at https://opensource.org/license/bsd-2-clause
+
+function get_counts(model)
+    n_constraints = 0
+    total_len_constraints = 0
+    n_variables = MOI.get(model, MOI.NumberOfVariables())
+    n_constants = 0
+    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+        n_constraints += MOI.get(model, MOI.NumberOfConstraints{F,S}())
+
+        for idx in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+            set = MOI.get(model, MOI.ConstraintSet(), idx)
+            total_len_constraints += MOI.dimension(set)
+            f = MOI.get(model, MOI.ConstraintFunction(), idx)
+            n_constants += count_size(f)
+        end
+    end
+    return (; n_variables, n_constraints, total_len_constraints, n_constants)
+end
+
+function count_size(f::MOI.VectorAffineFunction)
+    return length(f.terms) + length(f.constants)
+end
+
+function count_size(x)
+    error("Unknown:
+
+    $x
+
+    $(typeof(x))
+
+    $(propertynames(x))")
+    @show typeof(x)
+    @show propertynames(x)
+    return 0
+end
+
+function show_moi_counts(io::IO, model)
+    c = get_counts(model)
+    maybe_s(n) = n == 1 ? "" : "s"
+    print(io, c.n_variables, " scalar variable", maybe_s(c.n_variables))
+    print(
+        io,
+        ", ",
+        underscorise(c.n_constraints),
+        " constraint",
+        maybe_s(c.n_constraints),
+    )
+    if c.n_constraints > 0
+        print(
+            io,
+            " (",
+            underscorise(c.total_len_constraints),
+            " element",
+            maybe_s(c.total_len_constraints),
+            ")",
+        )
+    end
+    print(
+        io,
+        ", ",
+        underscorise(c.n_constants),
+        " sparse constant",
+        maybe_s(c.n_constants),
+    )
+    return nothing
+end

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -230,6 +230,11 @@ end
 
 function Base.show(io::IO, p::Problem)
     TreePrint.print_tree(io, p, MAXDEPTH[], MAXWIDTH[])
+    counts = counts_recursive(p)
+    bytes = Base.format_bytes(Base.summarysize(p))
+    print(io, "contains: ")
+    show(io, counts)
+    print(io, " (total: $bytes)")
     if p.status == MOI.OPTIMIZE_NOT_CALLED
         print(io, "\nstatus: `solve!` not called yet")
     else

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -217,10 +217,15 @@ function TreePrint.print_tree(io::IO, p::Problem, args...; kwargs...)
         args...;
         kwargs...,
     )
-    if !isempty(p.constraints)
+    all_constraints = copy(p.constraints)
+    for variable in
+        Iterators.filter(x -> x isa AbstractVariable, AbstractTrees.Leaves(p))
+        append!(all_constraints, get_constraints(variable))
+    end
+    if !isempty(all_constraints)
         TreePrint.print_tree(
             io,
-            ProblemConstraintsRoot(p.constraints),
+            ProblemConstraintsRoot(all_constraints),
             args...;
             kwargs...,
         )

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -236,13 +236,17 @@ end
 function Base.show(io::IO, p::Problem)
     TreePrint.print_tree(io, p, MAXDEPTH[], MAXWIDTH[])
     counts = counts_recursive(p)
-    bytes = Base.format_bytes(Base.summarysize(p))
-    print(io, "contains: ")
+    model_bytes = Base.summarysize(p.model)
+    bytes = Base.summarysize(p) - model_bytes
+    print(io, "expression tree: ")
     show(io, counts)
-    print(io, " (total: $bytes)")
+    print(io, " (total: ", Base.format_bytes(bytes), ")")
     if p.status == MOI.OPTIMIZE_NOT_CALLED
         print(io, "\nstatus: `solve!` not called yet")
     else
+        print(io, "\nreformulation: ")
+        show_moi_counts(io::IO, p.model)
+        print(io, " (total: ", Base.format_bytes(model_bytes), ")")
         print(io, "\ntermination status: $(p.status)")
         print(io, "\nprimal status: $(primal_status(p))")
         print(io, "\ndual status: $(dual_status(p))")

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -162,14 +162,16 @@ function counts(node::AbstractVariable)
 end
 
 function counts(node::GenericConstraint)
+    f = iscomplex(node) ? 2 : 1
     return Counts(;
         n_constraints = 1,
-        total_len_constraints = MOI.dimension(node.set),
+        total_len_constraints = f*MOI.dimension(node.set),
     )
 end
 
 function counts(node::Union{RelativeEntropyEpiCone,GeometricMeanHypoCone})
-    return Counts(; n_constraints = 1, total_len_constraints = node.size[1])
+    f = iscomplex(node) ? 2 : 1
+    return Counts(; n_constraints = 1, total_len_constraints = f*node.size[1])
 end
 
 function counts(node::Constant)

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -119,7 +119,7 @@ function Base.show(io::IO, c::Counts)
         end
         print(io, ")")
     end
-    print(io, ", ", underscorise(c.n_atoms), " atom", maybe_s(c.n_atoms))
+    print(io, ", and ", underscorise(c.n_atoms), " atom", maybe_s(c.n_atoms))
     return nothing
 end
 

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -12,9 +12,6 @@ AbstractTrees.children(v::AbstractVariable) = ()
 AbstractTrees.children(c::Constant) = ()
 
 AbstractTrees.children(C::Constraint) = (C.lhs, C.rhs)
-function AbstractTrees.children(C::RelativeEntropyEpiConeConstraint)
-    return (C.τ, C.cone.X, C.cone.Y)
-end
 
 AbstractTrees.printnode(io::IO, node::AbstractExpr) = summary(io, node)
 

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -12,6 +12,7 @@ AbstractTrees.children(v::AbstractVariable) = ()
 AbstractTrees.children(c::Constant) = ()
 
 AbstractTrees.children(C::Constraint) = (C.lhs, C.rhs)
+AbstractTrees.children(C::RelativeEntropyEpiConeConstraint) = (C.τ, C.cone)
 
 AbstractTrees.printnode(io::IO, node::AbstractExpr) = summary(io, node)
 
@@ -186,10 +187,28 @@ function counts(node::GenericConstraint)
     )
 end
 
-function counts(node::Union{RelativeEntropyEpiCone,GeometricMeanHypoCone})
-    f = iscomplex(node) ? 2 : 1
-    return Counts(; n_constraints = 1, total_len_constraints = f * node.size[1])
+function counts(node::GeometricMeanHypoCone)
+    return Counts()
 end
+
+function counts(node::RelativeEntropyEpiCone)
+    return Counts()
+end
+
+function counts(node::RelativeEntropyEpiConeConstraint)
+    f = iscomplex(node) ? 2 : 1
+    return Counts(; n_constraints = 1, total_len_constraints = f * node.cone.size[1])
+end
+
+
+function counts(node::Convex.GeometricMeanHypoConeConstraint)
+    f = iscomplex(node) ? 2 : 1
+    return Counts(; n_constraints = 1, total_len_constraints = f * node.cone.size[1])
+end
+
+
+# e.g. `satisfy` objectives
+counts(node::Nothing) = Counts()
 
 function counts(node::Constant)
     return Counts(;

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -38,3 +38,150 @@ function AbstractTrees.printnode(io::IO, node::Constant)
 end
 
 AbstractTrees.printnode(io::IO, node::AbstractVariable) = summary(io, node)
+
+Base.@kwdef struct Counts
+    n_atoms::Int = 0
+    n_variables::Int = 0
+    n_constants::Int = 0
+    n_constraints::Int = 0
+    total_len_variables::Int = 0
+    total_len_constraints::Int = 0
+    total_len_dense_constants::Int = 0
+    total_nnz_sparse_constants::Int = 0
+end
+
+# Borrowed from Flux
+function underscorise(n::Integer)
+    return join(
+        reverse(join.(reverse.(Iterators.partition(digits(n), 3)))),
+        '_',
+    )
+end
+
+function Base.show(io::IO, c::Counts)
+    maybe_s(n) = n == 1 ? "" : "s"
+    print(io, c.n_variables, " variable", maybe_s(c.n_variables))
+    if c.n_variables > 0
+        print(
+            io,
+            " (",
+            underscorise(c.total_len_variables),
+            " element",
+            maybe_s(c.total_len_variables),
+            ")",
+        )
+    end
+
+    print(
+        io,
+        ", ",
+        underscorise(c.n_constraints),
+        " constraint",
+        maybe_s(c.n_constraints),
+    )
+    if c.n_constraints > 0
+        print(
+            io,
+            " (",
+            underscorise(c.total_len_constraints),
+            " element",
+            maybe_s(c.total_len_constraints),
+            ")",
+        )
+    end
+    print(
+        io,
+        ", ",
+        underscorise(c.n_constants),
+        " constant",
+        maybe_s(c.n_constants),
+    )
+    if c.n_constants > 0
+        print(io, " (")
+        if c.total_len_dense_constants > 0
+            print(
+                io,
+                underscorise(c.total_len_dense_constants),
+                " dense element",
+                maybe_s(c.total_len_dense_constants),
+            )
+        end
+        if c.total_len_dense_constants > 0 && c.total_nnz_sparse_constants > 0
+            print(io, ", ")
+        end
+        if c.total_nnz_sparse_constants > 0
+            print(
+                io,
+                underscorise(c.total_nnz_sparse_constants),
+                " sparse nonzero",
+                maybe_s(c.total_nnz_sparse_constants),
+                ")",
+            )
+        end
+        print(io, ", ", underscorise(c.n_atoms), " atom", maybe_s(c.n_atoms))
+    end
+    return nothing
+end
+
+function Base.:(+)(c1::Counts, c2::Counts)
+    return Counts(
+        (getfield(c1, i) + getfield(c2, i) for i in 1:fieldcount(Counts))...,
+    )
+end
+
+Base.zero(::Type{Counts}) = Counts()
+
+# Don't double-count
+function single_count!(seen::Base.IdSet, node)
+    if node in seen
+        return zero(Counts)
+    else
+        push!(seen, node)
+        return counts(node)
+    end
+end
+
+function counts_recursive(node)
+    seen = Base.IdSet()
+    return sum(
+        c -> single_count!(seen, c),
+        AbstractTrees.PreOrderDFS(node);
+        init = zero(Counts),
+    )
+end
+
+# Here we define `counts` for each object.
+
+function counts(::AbstractExpr)
+    return Counts(; n_atoms = 1)
+end
+
+function counts(node::AbstractVariable)
+    f = iscomplex(node) ? 2 : 1
+    return Counts(; n_variables = 1, total_len_variables = f * length(node))
+end
+
+function counts(node::GenericConstraint)
+    return Counts(;
+        n_constraints = 1,
+        total_len_constraints = MOI.dimension(node.set),
+    )
+end
+
+function counts(node::Union{RelativeEntropyEpiCone,GeometricMeanHypoCone})
+    return Counts(; n_constraints = 1, total_len_constraints = node.size[1])
+end
+
+function counts(node::Union{Constant,ComplexConstant})
+    f = iscomplex(node) ? 2 : 1
+    return Counts(;
+        n_constants = 1,
+        total_len_dense_constants = SparseArrays.issparse(node.value) ? 0 :
+                                    f * length(node.value),
+        total_nnz_sparse_constants = SparseArrays.issparse(node.value) ?
+                                     f * SparseArrays.nnz(node.value) : 0,
+    )
+end
+
+# This node has no counts itself (we still count the children!)
+counts(::Vector{Constraint}) = zero(Counts)

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -12,7 +12,9 @@ AbstractTrees.children(v::AbstractVariable) = ()
 AbstractTrees.children(c::Constant) = ()
 
 AbstractTrees.children(C::Constraint) = (C.lhs, C.rhs)
-AbstractTrees.children(C::RelativeEntropyEpiConeConstraint) = (C.τ, C.cone)
+function AbstractTrees.children(C::RelativeEntropyEpiConeConstraint)
+    return (C.τ, C.cone.X, C.cone.Y)
+end
 
 AbstractTrees.printnode(io::IO, node::AbstractExpr) = summary(io, node)
 
@@ -187,25 +189,21 @@ function counts(node::GenericConstraint)
     )
 end
 
-function counts(node::GeometricMeanHypoCone)
-    return Counts()
-end
-
-function counts(node::RelativeEntropyEpiCone)
-    return Counts()
-end
-
 function counts(node::RelativeEntropyEpiConeConstraint)
     f = iscomplex(node) ? 2 : 1
-    return Counts(; n_constraints = 1, total_len_constraints = f * node.cone.size[1])
+    return Counts(;
+        n_constraints = 1,
+        total_len_constraints = f * node.cone.size[1],
+    )
 end
-
 
 function counts(node::Convex.GeometricMeanHypoConeConstraint)
     f = iscomplex(node) ? 2 : 1
-    return Counts(; n_constraints = 1, total_len_constraints = f * node.cone.size[1])
+    return Counts(;
+        n_constraints = 1,
+        total_len_constraints = f * node.cone.size[1],
+    )
 end
-
 
 # e.g. `satisfy` objectives
 counts(node::Nothing) = Counts()
@@ -217,6 +215,13 @@ function counts(node::Constant)
                                     length(node.value),
         total_nnz_sparse_constants = SparseArrays.issparse(node.value) ?
                                      SparseArrays.nnz(node.value) : 0,
+    )
+end
+
+function counts(node::Number)
+    return Counts(;
+        n_constants = 1,
+        total_len_dense_constants = iscomplex(node) ? 2 : 1,
     )
 end
 

--- a/test/test_problem_depot.jl
+++ b/test/test_problem_depot.jl
@@ -44,25 +44,6 @@ end
 test_problem_depot_load_Float64() = _test_problem_depot_load(Float64)
 test_problem_depot_load_BigFloat() = _test_problem_depot_load(BigFloat)
 
-function _test_problem_depot_show()
-    Convex.ProblemDepot.foreach_problem() do name, func
-        @testset "$name" begin
-            func(Val(false), 0.0, 0.0, Float64) do problem
-                @test sprint(show, problem) isa AbstractString
-                solve!(
-                    problem,
-                    Clarabel.Optimizer;
-                    silent_solver = true,
-                    warmstart = true,
-                )
-                @test sprint(show, problem) isa AbstractString
-                return
-            end
-        end
-    end
-    return
-end
-
 function test_Clarabel_warmstarts()
     # `sdp_quantum_relative_entropy3_lowrank` failed on CI for Ubuntu with
     #   Expression: ≈(p.optval, evaluate(quantum_relative_entropy(B, A)), atol = atol, rtol = rtol)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -170,6 +170,7 @@ function test_show()
     @test sign(p) == NoSign()
     @test curvature(p) == Convex.ConvexVexity()
 
+    bytes = Base.format_bytes(Base.summarysize(p))
     @test sprint(show, p) == """
     maximize
     └─ log (concave; real)
@@ -183,7 +184,7 @@ function test_show()
        └─ + (affine; real)
           ├─ real variable ($(Convex.show_id(x)))
           └─ $(reshape([-3], 1, 1))
-
+    expression tree: 1 variable (1 element), 2 constraints (2 elements), 2 constants (2 dense elements), and 4 atoms (total: $bytes)
     status: `solve!` not called yet"""
 
     x = ComplexVariable(2, 3)
@@ -204,6 +205,7 @@ function test_show()
     root = hcat(level2, level2)
     p = minimize(sum(x), root == root)
     @test curvature(p) == Convex.ConstVexity()
+    bytes = Base.format_bytes(Base.summarysize(p))
     @test sprint(show, p) == """
         minimize
         └─ sum (affine; real)
@@ -216,7 +218,7 @@ function test_show()
               │  └─ …
               └─ Convex.NegateAtom (affine; real)
                  └─ …
-
+        expression tree: 2 variables (4 elements), 1 constraint (16 elements), 0 constants, and 7 atoms (total: $bytes)
         status: `solve!` not called yet"""
 
     # test `MAXWIDTH`
@@ -226,6 +228,7 @@ function test_show()
     @test_throws err sign(p)
     old_maxwidth = Convex.MAXWIDTH[]
     Convex.MAXWIDTH[] = 2
+    bytes = Base.format_bytes(Base.summarysize(p))
     @test sprint(show, p) == """
         satisfy
         └─ nothing
@@ -239,7 +242,7 @@ function test_show()
         │     ├─ real variable ($(Convex.show_id(x)))
         │     └─ $(reshape([-2], 1, 1))
         ⋮
-
+        expression tree: 1 variable (1 element), 100 constraints (100 elements), 100 constants (100 dense elements), and 101 atoms (total: $bytes)
         status: `solve!` not called yet"""
     Convex.MAXWIDTH[] = old_maxwidth
 
@@ -254,6 +257,10 @@ function test_show()
             "eps_abs" => 1e-6,
         ),
     )
+    bytes = Base.summarysize(p)
+    model_bytes = Base.summarysize(p.model)
+    str1 = Base.format_bytes(bytes - model_bytes)
+    str2 = Base.format_bytes(model_bytes)
     @test sprint(show, p) == """
             satisfy
             └─ nothing
@@ -262,7 +269,8 @@ function test_show()
                └─ + (affine; real)
                   ├─ real variable ($(Convex.show_id(x)))
                   └─ $(reshape([0], 1, 1))
-
+            expression tree: 1 variable (1 element), 1 constraint (1 element), 1 constant (1 dense element), and 2 atoms (total: $str1)
+            reformulation: 1 scalar variable, 1 constraint (1 element), 2 sparse constants (total: $str2)
             termination status: OPTIMAL
             primal status: FEASIBLE_POINT
             dual status: FEASIBLE_POINT"""


### PR DESCRIPTION
closes https://github.com/jump-dev/Convex.jl/issues/640 closes #644 

I haven't written tests yet since I'd like to get feedback on the printing before that. The problem

```julia
A = [1 2im 3 4; 4im 3im 2 1; 4 5 6 7]
y = ComplexVariable(3, 4)
p = minimize(nuclearnorm(y), y == A)
```
results in 

```julia
julia> p = minimize(nuclearnorm(y), y == A)
minimize
└─ nuclearnorm (convex; positive)
   └─ 3×4 complex variable (id: 179…837)
subject to
└─ == constraint (affine)
   └─ + (affine; complex)
      ├─ 3×4 complex variable (id: 179…837)
      └─ 3×4 complex constant
contains: 1 variable (24 elements), 1 constraint (24 elements), 1 constant (24 dense elements), and 3 atoms (total: 736 bytes)
status: `solve!` not called yet
```
where the "contains" line is new.

The problem from #254 in our benchmarks results in
```julia
julia> problem
maximize
└─ + (concave; real)
   ├─ Convex.NegateAtom (concave; real)
   │  └─ + (convex; real)
   │     ├─ …
   │     └─ …
   └─ Convex.NegateAtom (affine; real)
      └─ sum (affine; real)
         └─ …
subject to
├─ ≥ constraint (affine)
│  └─ + (affine; real)
│     ├─ 2730-element real variable (id: 863…744)
│     └─ Convex.NegateAtom (constant; positive)
│        └─ …
└─ ≤ constraint (affine)
   └─ + (affine; real)
      ├─ 2730-element real variable (id: 863…744)
      └─ Convex.NegateAtom (constant; negative)
         └─ …
contains: 1 variable (2_730 elements), 2 constraints (5_460 elements), 8 constants (9_462 dense elements, 22_000 sparse nonzeros), and 22 atoms (total: 456.781 KiB)
status: `solve!` not called yet
```

etc.

Note that the counts are of the problem as formulated by the user, NOT as reformulated by Convex during `conic_form`. Since `show` can happen before the MOI model is formulated, and I do the counting on the Conevx.jl expression tree.

I think this is good and bad. The good is that the values are easy to understand; you get 1 variable since you wrote down 1 variable, etc. If the user does a bunch of scalar indexing etc, they will get many atoms. However, it is not so easy to use these counts to notice performance issues stemming from bad `conic_form!` reformulations; e.g., we would see the same values pre- and post- #618 since the change was only in `conic_form!`. But we shouldn't have many of those anymore, so maybe it's not a big deal.

We could also count things at the MOI level post-reformulation. I think that is less useful (especially for `show`), since it's nice to get a quick sense of the problem *before* you go to solve it.