### PR TITLE
[breaking] Cleanup the `Context` object: remove `id_hash`, simplify dictionaries

### DIFF
--- a/docs/src/examples/mixed_integer/aux_files/antidiag.jl
+++ b/docs/src/examples/mixed_integer/aux_files/antidiag.jl
@@ -14,9 +14,8 @@ export antidiag
 
 ### Diagonal
 ### Represents the kth diagonal of an mxn matrix as a (min(m, n) - k) x 1 vector
-struct AntidiagAtom <: Convex.AbstractExpr
+mutable struct AntidiagAtom <: Convex.AbstractExpr
     head::Symbol
-    id_hash::UInt64
     children::Tuple{Convex.AbstractExpr}
     size::Tuple{Int,Int}
     k::Int
@@ -29,7 +28,6 @@ struct AntidiagAtom <: Convex.AbstractExpr
         children = (x,)
         return new(
             :antidiag,
-            hash((children, k)),
             children,
             (minimum(x.size) - k, 1),
             k,

--- a/docs/src/examples/mixed_integer/aux_files/antidiag.jl
+++ b/docs/src/examples/mixed_integer/aux_files/antidiag.jl
@@ -26,12 +26,7 @@ mutable struct AntidiagAtom <: Convex.AbstractExpr
             error("Bounds error in calling diag")
         end
         children = (x,)
-        return new(
-            :antidiag,
-            children,
-            (minimum(x.size) - k, 1),
-            k,
-        )
+        return new(:antidiag, children, (minimum(x.size) - k, 1), k)
     end
 end
 

--- a/docs/src/manual/advanced.md
+++ b/docs/src/manual/advanced.md
@@ -131,16 +131,15 @@ this. To do so, we define
 
 ```@example 1
 using Convex
+
+# Must be mutable! Otherwise variables with the same size/value would be treated as the same object.
 mutable struct ProbabilityVector <: Convex.AbstractVariable
     head::Symbol
-    id_hash::UInt64
-    size::Tuple{Int, Int}
+    size::Tuple{Int,Int}
     value::Union{Convex.Value,Nothing}
     vexity::Convex.Vexity
     function ProbabilityVector(d)
-        this = new(:ProbabilityVector, 0, (d,1), nothing, Convex.AffineVexity())
-        this.id_hash = objectid(this)
-        this
+        return new(:ProbabilityVector, (d, 1), nothing, Convex.AffineVexity())
     end
 end
 
@@ -165,8 +164,8 @@ solve!(prob, SCS.Optimizer)
 evaluate(p) # [1.0, 0.0, 0.0]
 ```
 
-Subtypes of `AbstractVariable` must have the fields `head`, `id_hash`, and
-`size`, and `id_hash` must be populated as shown in the example. Then they must also
+Subtypes of `AbstractVariable` must have the fields `head` and
+`size`. Then they must also
 
 * either have a field `value`, or implement [`Convex._value`](@ref) and
   [`Convex.set_value!`](@ref)

--- a/src/Context.jl
+++ b/src/Context.jl
@@ -8,15 +8,13 @@ mutable struct Context{T,M}
     model::M
 
     # Used for populating variable values after solving
-    var_id_to_moi_indices::OrderedCollections.OrderedDict{
-        UInt64,
+    var_to_moi_indices::IdDict{
+        Any,
         Union{
             Vector{MOI.VariableIndex},
             Tuple{Vector{MOI.VariableIndex},Vector{MOI.VariableIndex}},
         },
     }
-    # `id_hash` -> `AbstractVariable`
-    id_to_variables::OrderedCollections.OrderedDict{UInt64,Any}
 
     # Used for populating constraint duals
     constr_to_moi_inds::IdDict{Any,Any}
@@ -24,7 +22,6 @@ mutable struct Context{T,M}
     detected_infeasible_during_formulation::Bool
 
     # Cache
-    # conic_form_cache::DataStructures.WeakKeyIdDict{Any, Any}
     conic_form_cache::IdDict{Any,Any}
 end
 
@@ -39,8 +36,13 @@ function Context{T}(optimizer_factory; add_cache::Bool = false) where {T}
     end
     return Context{T,typeof(model)}(
         model,
-        OrderedCollections.OrderedDict{UInt64,Vector{MOI.VariableIndex}}(),
-        OrderedCollections.OrderedDict{UInt64,Any}(),
+        IdDict{
+            Any,
+            Union{
+                Vector{MOI.VariableIndex},
+                Tuple{Vector{MOI.VariableIndex},Vector{MOI.VariableIndex}},
+            },
+        }(),
         IdDict{Any,Any}(),
         false,
         IdDict{Any,Any}(),
@@ -49,8 +51,7 @@ end
 
 function Base.empty!(context::Context)
     MOI.empty!(context.model)
-    empty!(context.var_id_to_moi_indices)
-    empty!(context.id_to_variables)
+    empty!(context.var_to_moi_indices)
     empty!(context.constr_to_moi_inds)
     context.detected_infeasible_during_formulation = false
     empty!(context.conic_form_cache)

--- a/src/Context.jl
+++ b/src/Context.jl
@@ -21,7 +21,7 @@ mutable struct Context{T,M}
     # Used for populating constraint duals
     constr_to_moi_inds::IdDict{Any,Any}
 
-    detected_infeasible_during_formulation::Ref{Bool}
+    detected_infeasible_during_formulation::Bool
 
     # Cache
     # conic_form_cache::DataStructures.WeakKeyIdDict{Any, Any}
@@ -52,7 +52,7 @@ function Base.empty!(context::Context)
     empty!(context.var_id_to_moi_indices)
     empty!(context.id_to_variables)
     empty!(context.constr_to_moi_inds)
-    context.detected_infeasible_during_formulation[] = false
+    context.detected_infeasible_during_formulation = false
     empty!(context.conic_form_cache)
     return
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -5,7 +5,7 @@
 
 struct Optimizer{T,M} <: MOI.AbstractOptimizer
     context::Context{T,M}
-    moi_to_convex::OrderedCollections.OrderedDict{MOI.VariableIndex,UInt64}
+    moi_to_convex::OrderedCollections.OrderedDict{MOI.VariableIndex,Any}
     convex_to_moi::Dict{UInt64,Vector{MOI.VariableIndex}}
     constraint_map::Vector{MOI.ConstraintIndex}
     function Optimizer(context::Context{T,M}) where {T,M}
@@ -47,9 +47,8 @@ end
 
 function _add_variable(model::Optimizer, vi::MOI.VariableIndex)
     var = Variable()
-    model.moi_to_convex[vi] = var.id_hash
-    model.context.var_id_to_moi_indices[var.id_hash] = [vi]
-    model.context.id_to_variables[var.id_hash] = var
+    model.moi_to_convex[vi] = var
+    model.context.var_to_moi_indices[var] = [vi]
     return
 end
 
@@ -129,7 +128,7 @@ function _expr(::Optimizer, v::Value)
 end
 
 function _expr(model::Optimizer, x::MOI.VariableIndex)
-    return model.context.id_to_variables[model.moi_to_convex[x]]
+    return model.moi_to_convex[x]
 end
 
 function _expr(model::Optimizer, f::MOI.AbstractScalarFunction)

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -38,7 +38,6 @@ end
 
 mutable struct Constant{T<:Real} <: AbstractExpr
     head::Symbol
-    id_hash::UInt64
     value::Union{Matrix{T},SPARSE_MATRIX{T}}
     size::Tuple{Int,Int}
     sign::Sign
@@ -47,13 +46,7 @@ mutable struct Constant{T<:Real} <: AbstractExpr
         if x isa Complex || x isa AbstractArray{<:Complex}
             throw(DomainError(x, "Constant expects real values"))
         end
-        return new{eltype(x)}(
-            :constant,
-            objectid(x),
-            _matrix(x),
-            _size(x),
-            sign,
-        )
+        return new{eltype(x)}(:constant, _matrix(x), _size(x), sign)
     end
 end
 function Constant(x::Value, check_sign::Bool = true)
@@ -63,13 +56,12 @@ end
 
 mutable struct ComplexConstant{T<:Real} <: AbstractExpr
     head::Symbol
-    id_hash::UInt64
     size::Tuple{Int,Int}
     real_constant::Constant{T}
     imag_constant::Constant{T}
     function ComplexConstant(re::Constant{T}, im::Constant{T}) where {T}
         size(re) == size(im) || error("size mismatch")
-        return new{T}(:complex_constant, rand(UInt64), size(re), re, im)
+        return new{T}(:complex_constant, size(re), re, im)
     end
 
     # function ComplexConstant(re::Constant{S1}, im::Constant{S2}) where {S1,S2}

--- a/src/constraints/GenericConstraint.jl
+++ b/src/constraints/GenericConstraint.jl
@@ -87,7 +87,7 @@ end
 function _add_constraint!(context::Context, c::GenericConstraint)
     if vexity(c.child) == ConstVexity()
         if !is_feasible(evaluate(c.child), c.set, CONSTANT_CONSTRAINT_TOL[])
-            context.detected_infeasible_during_formulation[] = true
+            context.detected_infeasible_during_formulation = true
         end
         return
     end

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -40,8 +40,7 @@ const Value = Union{Number,AbstractArray}
 # We commandeer `==` to create a constraint.
 # Therefore we define `isequal` to still have a notion of equality
 # (Normally `isequal` falls back to `==`, so we need to provide a method).
-# All `AbstractExpr` (Constraints are not AbstractExpr's!) are compared by value, except for AbstractVariables,
-# which use their `id_hash` field.
+# All `AbstractExpr` (Constraints are not AbstractExpr's!) are compared by value, except for AbstractVariables, which are compared by `===` (objectid).
 function Base.isequal(x::AbstractExpr, y::AbstractExpr)
     if typeof(x) != typeof(y)
         return false

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -97,7 +97,7 @@ function solve!(
     if warmstart && MOI.supports(context.model, attr, MOI.VariableIndex)
         _add_variable_primal_start(context)
     end
-    if context.detected_infeasible_during_formulation[]
+    if context.detected_infeasible_during_formulation
         p.status = MOI.INFEASIBLE
     else
         MOI.optimize!(context.model)

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -39,8 +39,7 @@ end
 
 function _add_variable_primal_start(context::Convex.Context{T}) where {T}
     attr = MOI.VariablePrimalStart()
-    for (id, moi_indices) in context.var_id_to_moi_indices
-        x = context.id_to_variables[id]
+    for (x, moi_indices) in context.var_to_moi_indices
         if x.value === nothing
             continue
         elseif moi_indices isa Tuple  # Variable is complex
@@ -108,8 +107,7 @@ function solve!(
         @warn "Problem wasn't solved optimally" status = p.status
     end
     primal_status = MOI.get(context.model, MOI.PrimalStatus())
-    for (id, indices) in context.var_id_to_moi_indices
-        var = context.id_to_variables[id]
+    for (var, indices) in context.var_to_moi_indices
         if vexity(var) == ConstVexity()
             continue  # Fixed variable
         elseif primal_status == MOI.NO_SOLUTION

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -8,7 +8,7 @@ using .TreePrint
 """
     show_id(io::IO, x::Union{AbstractVariable}; digits = 3)
 
-Print a truncated version of the objects `id_hash` field.
+Print a truncated version of the object's id.
 
 ## Example
 
@@ -19,12 +19,12 @@ julia> Convex.show_id(stdout, x)
 id: 163…906
 ```
 """
-function show_id(io::IO, x::Union{AbstractVariable}; digits = MAXDIGITS[])
+function show_id(io::IO, x::AbstractVariable; digits = MAXDIGITS[])
     return print(io, show_id(x; digits = digits))
 end
 
-function show_id(x::Union{AbstractVariable}; digits = MAXDIGITS[])
-    hash_str = string(x.id_hash)
+function show_id(x::AbstractVariable; digits = MAXDIGITS[])
+    hash_str = string(objectid(x))
     if length(hash_str) > (2 * digits + 1)
         return "id: " * first(hash_str, digits) * "…" * last(hash_str, digits)
     else

--- a/src/variable_template.jl
+++ b/src/variable_template.jl
@@ -6,15 +6,13 @@
 # It might be useful to get a direct VOV sometimes...
 function _template(a::AbstractVariable, context::Context{T}) where {T}
     first_cache = false
-    var_inds = get!(context.var_id_to_moi_indices, a.id_hash) do
+    var_inds = get!(context.var_to_moi_indices, a) do
         first_cache = true
         return add_variables!(context.model, a)
     end
 
-    context.id_to_variables[a.id_hash] = a
-
     # we only want this to run once, when the variable is first added,
-    # and after `var_id_to_moi_indices` is populated
+    # and after `var_to_moi_indices` is populated
     if first_cache
         if sign(a) == Positive()
             add_constraint!(context, a >= 0)
@@ -97,18 +95,6 @@ accessed in `context[a]`, otherwise, it is created by calling
 with the same expression does not create a duplicate one.
 """
 function conic_form!(context::Context, a::AbstractExpr)
-
-    # Nicer implementation
     d = context.conic_form_cache
     return get!(() -> new_conic_form!(context, a), d, a)
-
-    # Avoid closure
-    # wkh = context.conic_form_cache
-    # default = () -> new_conic_form!(context, a)
-    # key = a
-    # return Base.@lock wkh.lock begin
-    #     get!(default, wkh.ht, DataStructures.WeakRefForWeakDict(key))
-    # end
-
-    return
 end


### PR DESCRIPTION
We are using `objectid` as our hash, since there are no collisions thanks to the Julia runtime. We are using this as keys in dictionaries inside the `Context` object. However, an `IdDict` is exactly a dict that uses `objectid` for lookup. This also makes making new AbstractVariables a bit easier, although they still need to be mutable. (Before they had to be mutable and you had to set the `id_hash` yourself).

I don't expect this to necessarily have any performance implications, but `IdDict`s should be quite fast (since there's no hashing involved), and I think this should reduce the likelihood of bugs. E.g. I noticed in `ComplexConstant` we were generating the `id_hash` randomly (for some reason), which does have the chance of collision. We are still fairly type unstable, as before.

## Breakingness

I tagged this breaking since the instructions on how to create a custom AbstractVariable have changed. However, I don't think it is very breaking in practice; if you followed the old advice and had a mutable object with an `id_hash` field, it should still work fine, we just no longer inspect the `id_hash` field. However if you had an immutable variable type, and you distinguished instances via the `id_hash` value, now you will get collisions. I think there are essentially 0 users of the AbstractVariable interface in the wild though, so IMO it's worth cleaning up now.

## Aside on ordering

This PR has the potential to regress on https://github.com/jump-dev/Convex.jl/issues/488, since this drops the ordering from some dictionaries, and we don't have a test for #488. However, I've looked through the code, and I don't think we actually rely on dictionary iteration ordering **anywhere** with these dictionaries. We only iterate to retrieve results from MOI, not to add variables/constraints (since those get added during `conic_form!` whose order is determined by the problem formulation).

The PR that fixed #488 also changed a dictionary inside `Hcat`, which we definitely *did* use iteration order to choose the order of objects that got added to the model:

https://github.com/jump-dev/Convex.jl/blob/4f52b6fd4c446cda55e77201037ae22043da2c67/src/atoms/affine/stack.jl#L87

I suspect this was the real fix. We no longer build the hcat atom in such a complicated way, and this dictionary has been deleted as far as I can tell.

I did run the problem from #488 a couple times (recreating it from scratch) and got the same results (even the same values of the variable `X1` and the objective), as well.