### PR TITLE
add outer testset to docs and fix example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,7 +39,7 @@ function _literate_directory(dir)
 end
 
 if !SKIP_EXAMPLES
-    Test.@testset "Examples" verbose=true begin
+    Test.@testset "Examples" verbose = true begin
         for (root, dir, files) in walkdir(joinpath(@__DIR__, "src", "examples"))
             _literate_directory.(joinpath.(root, dir))
         end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,8 +39,10 @@ function _literate_directory(dir)
 end
 
 if !SKIP_EXAMPLES
-    for (root, dir, files) in walkdir(joinpath(@__DIR__, "src", "examples"))
-        _literate_directory.(joinpath.(root, dir))
+    Test.@testset "Examples" verbose=true begin
+        for (root, dir, files) in walkdir(joinpath(@__DIR__, "src", "examples"))
+            _literate_directory.(joinpath.(root, dir))
+        end
     end
 end
 

--- a/docs/src/examples/general_examples/worst_case_analysis.jl
+++ b/docs/src/examples/general_examples/worst_case_analysis.jl
@@ -1,14 +1,14 @@
 # # Worst case risk analysis
 # Generate data for worst-case risk analysis.
 using Random
-
+using LinearAlgebra
 Random.seed!(2);
 n = 5;
 r = abs.(randn(n, 1)) / 15;
 Sigma = 0.9 * rand(n, n) .- 0.15;
 Sigma_nom = Sigma' * Sigma;
 Sigma_nom .-= (maximum(Sigma_nom) - 0.9)
-
+Sigma_nom .+= (1e-4 - eigmin(Sigma_nom)) * I(n) # ensure positive-definite
 #-
 
 # Form and solve portfolio optimization problem.


### PR DESCRIPTION
locally the example was failing for me. I think it could depend on the exact random stream whether or not the matrix is positive-definite, as required by `quadform`; here, I ensure it.

The outer testset collects handy timings for us:

```
Test Summary:                                                                                                          | Pass  Total     Time
Examples                                                                                                               |   32     32  1m19.5s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/DCP_analysis.jl                                              |        None     0.0s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/basic_usage.jl                                               |        None     0.1s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/chebyshev_center.jl                                          |        None     0.3s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/control.jl                                                   |        None     0.1s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/dualization.jl                                               |        None     3.7s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/huber_regression.jl                                          |        None     0.2s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/lasso_regression.jl                                          |        None     1.1s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/logistic_regression.jl                                       |        None     0.1s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/max_entropy.jl                                               |        None     0.0s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/optimal_advertising.jl                                       |        None     0.1s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/robust_approx_fitting.jl                                     |        None     0.0s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/svm.jl                                                       |        None     0.0s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/svm_l1regularization.jl                                      |        None    35.7s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/trade_off_curves.jl                                          |        None     0.8s
  /Users/eph/Convex.jl/docs/src/examples/general_examples/worst_case_analysis.jl                                       |        None     0.3s
  /Users/eph/Convex.jl/docs/src/examples/mixed_integer/binary_knapsack.jl                                              |        None     0.0s
  /Users/eph/Convex.jl/docs/src/examples/mixed_integer/n_queens.jl                                                     |   28     28     0.1s
  /Users/eph/Convex.jl/docs/src/examples/mixed_integer/section_allocation.jl                                           |        None     0.1s
  /Users/eph/Convex.jl/docs/src/examples/optimization_with_complex_variables/Fidelity in Quantum Information Theory.jl |        None     7.9s
  /Users/eph/Convex.jl/docs/src/examples/optimization_with_complex_variables/phase_recovery_using_MaxCut.jl            |        None     0.6s
  /Users/eph/Convex.jl/docs/src/examples/optimization_with_complex_variables/povm_simulation.jl                        |        None     0.2s
  /Users/eph/Convex.jl/docs/src/examples/optimization_with_complex_variables/power_flow_optimization.jl                |    4      4     0.2s
  /Users/eph/Convex.jl/docs/src/examples/portfolio_optimization/portfolio_optimization.jl                              |        None     0.0s
  /Users/eph/Convex.jl/docs/src/examples/portfolio_optimization/portfolio_optimization2.jl                             |        None     0.8s
  /Users/eph/Convex.jl/docs/src/examples/supplemental_material/Convex.jl_intro_ISMP2015.jl                             |        None     0.1s
  /Users/eph/Convex.jl/docs/src/examples/supplemental_material/paper_examples.jl                                       |        None     1.2s
  /Users/eph/Convex.jl/docs/src/examples/time_series/time_series.jl                                                    |        None     1.5s
  /Users/eph/Convex.jl/docs/src/examples/tomography/tomography.jl                                                      |        None    23.9s
```