### PR TITLE
`solve!` returns the problem

### DIFF
--- a/src/solution.jl
+++ b/src/solution.jl
@@ -65,7 +65,7 @@ end
 
 Solves the problem, populating `problem.optval` with the optimal value, as well
 as the values of the variables (accessed by [`evaluate`](@ref)) and constraint
-duals (accessed by `cons.dual`), where applicable.
+duals (accessed by `cons.dual`), where applicable. Returns the input `problem`.
 
 Optional keyword arguments:
 
@@ -134,7 +134,7 @@ function solve!(
             populate_dual!(context.model, c, indices)
         end
     end
-    return
+    return p
 end
 
 function populate_dual!(::MOI.ModelLike, c::Constraint, ::Nothing)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -42,7 +42,7 @@ function solve_and_return_output(problem, solver; kwargs...)
     return fetch(out_task)
 end
 
-function test_solve!_does_not_return_anything()
+function test_solve!_returns_the_problem()
     x = Variable()
     p = satisfy(x >= 0)
     output = solve!(
@@ -53,7 +53,7 @@ function test_solve!_does_not_return_anything()
             "eps_abs" => 1e-6,
         ),
     )
-    @test output === nothing
+    @test output === p
     return
 end
 
@@ -85,7 +85,7 @@ function test_solve!_can_take_an_optimizer_directly()
             "eps_abs" => 1e-6,
         ),
     )
-    @test output === nothing
+    @test output === p
     return
 end
 


### PR DESCRIPTION
Currently it returns `nothing`. I think this is nicer since then you get the solution summary printed after you do `solve!`, along with a summary of the problem. It's possible this can help users notice issues if they weren't looking at the problem, but did `solve!` in the REPL and noticed the output. In addition, looking at some of the examples like https://jump.dev/Convex.jl/dev/examples/mixed_integer/n_queens/, this would add more details to the example without needing a separate example block to show the problem first.

There is currently an explicit test that we return `nothing`, so I traced back the origin of that test to see why (in case there's some particular reason we need to return `nothing`). I believe it was added in https://github.com/jump-dev/Convex.jl/pull/62 originally, and was carried forward in various formats since then (eventually in its own testset once we added the problem depot since `handle_problem` there doesn't necessarily call `solve!`). Looking at that PR, I don't think returning `nothing` was necessarily important for anything, it was just testing what we were currently doing then.