### PR TITLE
cleanup: delete internal type `VectorAffineFunctionAsMatrix`

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -224,7 +224,7 @@ for (root, _, files) in walkdir(joinpath(@__DIR__, "constraints"))
 end
 
 include("SparseTape.jl")
-include("VectorAffineFunctionAsMatrix.jl")
+include("to_MOI.jl")
 include("ComplexTape.jl")
 include("operate.jl")
 include("complex_operate.jl")

--- a/src/to_MOI.jl
+++ b/src/to_MOI.jl
@@ -25,15 +25,11 @@ function to_vaf(tape::SparseTape{T}) where {T}
     return MOI.VectorAffineFunction{T}(vats, tape.operation.vector)
 end
 
-# method for adding constraints and coverting to standard VAFs as needed
+# method for adding constraints and converting to standard VAFs as needed
 function MOI_add_constraint(model, f, set)
     return MOI.add_constraint(model, f, set)
 end
 
-function MOI_add_constraint(
-    model,
-    f::Union{VectorAffineFunctionAsMatrix,SparseTape},
-    set,
-)
+function MOI_add_constraint(model, f::SparseTape, set)
     return MOI_add_constraint(model, to_vaf(f), set)
 end


### PR DESCRIPTION
This was initially a different thing from a `SparseTape`, since that was lazy, but they eventually merged to become the exact same thing. I think I meant to drop it from #504 but forgot.