### PR TITLE
Drop default `MAXWIDTH` to 3 (from 15)

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -131,11 +131,11 @@ const MAXDEPTH = Ref(3)
 """
     MAXWIDTH
 
-Controls width of tree printing globally for Convex.jl; defaults to 5. Set via
+Controls width of tree printing globally for Convex.jl; defaults to 3. Set via
 
     Convex.MAXWIDTH[] = 10
 """
-const MAXWIDTH = Ref(5)
+const MAXWIDTH = Ref(3)
 
 """
     MAXDIGITS

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -131,11 +131,11 @@ const MAXDEPTH = Ref(3)
 """
     MAXWIDTH
 
-Controls width of tree printing globally for Convex.jl; defaults to 15. Set via
+Controls width of tree printing globally for Convex.jl; defaults to 5. Set via
 
-    Convex.MAXWIDTH[] = 15
+    Convex.MAXWIDTH[] = 10
 """
-const MAXWIDTH = Ref(15)
+const MAXWIDTH = Ref(5)
 
 """
     MAXDIGITS


### PR DESCRIPTION
This dramatically shortens the printing in some cases, like the problem in https://jump.dev/Convex.jl/dev/examples/mixed_integer/n_queens/. I think showing so many constraints isn't useful, and one can dig into the problem themselves if needed. Not really sure why I chose such a big value in the first place in https://github.com/jump-dev/Convex.jl/pull/345.