### PR TITLE
`show`: add underscores to number of atoms and coefficients

### DIFF
--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -253,8 +253,12 @@ function Base.show(io::IO, p::Problem)
     con_str =
         _str_with_elements(counts.n_constraints, counts.n_scalar_constraints)
     println(io, "  number of constraints  : ", con_str)
-    println(io, "  number of coefficients : ", counts.n_nonzeros)
-    println(io, "  number of atoms        : ", counts.n_atoms)
+    println(
+        io,
+        "  number of coefficients : ",
+        _to_underscore(counts.n_nonzeros),
+    )
+    println(io, "  number of atoms        : ", _to_underscore(counts.n_atoms))
     println(io)
     # Print solution summary
     println(io, "Solution summary")


### PR DESCRIPTION
noticed in https://jump.dev/Convex.jl/dev/examples/supplemental_material/paper_examples/
<img width="818" alt="Screenshot 2024-05-14 at 23 12 16" src="https://github.com/jump-dev/Convex.jl/assets/5846501/b3fad876-6e47-4630-ae88-5750b6dbffbc">

I think I'll do a quick pass tomorrow through the examples and spruce them up a bit