### PR TITLE
Simplify constraint creation of MOI wrapper

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -193,24 +193,12 @@ function MOI.get(::Optimizer, ::MOI.ListOfSupportedNonlinearOperators)
     return Symbol[:+, :-, :*, :/, :^, :min, :max, :abs, :sqrt, :exp, :log]
 end
 
-function _constraint(expr::AbstractExpr, set::MOI.EqualTo)
-    return expr == MOI.constant(set)
-end
-
-function _constraint(expr::AbstractExpr, set::MOI.LessThan)
-    return expr <= MOI.constant(set)
-end
-
-function _constraint(expr::AbstractExpr, set::MOI.GreaterThan)
-    return expr >= MOI.constant(set)
-end
-
 function MOI.add_constraint(
     model::Optimizer{T},
     func::MOI.ScalarNonlinearFunction,
     set::MOI.AbstractScalarSet,
 ) where {T}
-    constraint = _constraint(_expr(model, func), set)
+    constraint = Constraint(_expr(model, func), set)
     add_constraint!(model.context, constraint)
     push!(model.constraint_map, model.context.constr_to_moi_inds[constraint])
     return MOI.ConstraintIndex{typeof(func),typeof(set)}(


### PR DESCRIPTION
Part of the goal of redesigning the constraints on top of MOI sets is to render the conversion from MOI constraints trivial.
In this PR, the MOI wrapper is still only supporting `LessThan`, `GreaterThan` and `EqualTo` but we can after easily target other sets such as `Nonnegatives`

I guess we have two options

1. Make `Convex.Constraint` work with `MOI.AbstractScalarSet` such as `LessThan`
2. Make `Convex.Optimizer` not support `ScalarNonlinearFunction`-in-`LessThan` but support `VectorNonlinearFunction`-in-`Nonpositives` so that the `VectorizeBridge` would deliver vector sets only.

I kind of prefer the second option

Closes https://github.com/jump-dev/Convex.jl/pull/669