### PR TITLE
Deprecate `silent_solver` to `silent`

### DIFF
--- a/docs/src/examples/general_examples/basic_usage.jl
+++ b/docs/src/examples/general_examples/basic_usage.jl
@@ -26,7 +26,7 @@ A = I(4)
 b = [10; 10; 10; 10]
 constraints = [A * x <= b, x >= 1, x <= 10, x[2] <= 5, x[1] + x[4] - x[2] <= 10]
 p = minimize(dot(c, x), constraints) # or c' * x
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 # We can also inspect the objective value and the values of the variables at the solution:
 println(round(p.optval, digits = 2))
@@ -50,7 +50,7 @@ X = Variable(2, 2)
 y = Variable()
 ## X is a 2 x 2 variable, and y is scalar. X' + y promotes y to a 2 x 2 variable before adding them
 p = minimize(norm(X) + y, 2 * X <= 1, X' + y >= 1, X >= 0, y >= 0)
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 # We can also inspect the values of the variables at the solution:
 println(round.(evaluate(X), digits = 2))
@@ -76,13 +76,13 @@ p = satisfy(
     x[2] >= 7,
     geomean(x[3], x[4]) >= x[2],
 )
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 # ### PSD cone and Eigenvalues
 
 y = Semidefinite(2)
 p = maximize(eigmin(y), tr(y) <= 6)
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 #-
 
@@ -91,7 +91,7 @@ y = Variable((2, 2))
 
 ## PSD constraints
 p = minimize(x + y[1, 1], y ⪰ 0, x >= 1, y[2, 1] == 1)
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 # ### Mixed integer program
 #
@@ -106,7 +106,7 @@ solve!(p, SCS.Optimizer; silent_solver = true)
 
 x = Variable(4, IntVar)
 p = minimize(sum(x), x >= 0.5)
-solve!(p, GLPK.Optimizer; silent_solver = true)
+solve!(p, GLPK.Optimizer; silent = true)
 
 # And the value of `x` at the solution:
 evaluate(x)

--- a/docs/src/examples/general_examples/chebyshev_center.jl
+++ b/docs/src/examples/general_examples/chebyshev_center.jl
@@ -29,7 +29,7 @@ constraints = [
     a4' * x_c + r * norm(a4, 2) <= b[4],
 ]
 p = maximize(r, constraints)
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 # Generate the figure
 x = range(-1.5, stop = 1.5, length = 100);

--- a/docs/src/examples/general_examples/control.jl
+++ b/docs/src/examples/general_examples/control.jl
@@ -121,7 +121,7 @@ push!(constraints, velocity[:, T] == 0)
 
 ## Solve the problem
 problem = minimize(sumsquares(force), constraints)
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 
 # We can plot the trajectory taken by the object.
 

--- a/docs/src/examples/general_examples/dualization.jl
+++ b/docs/src/examples/general_examples/dualization.jl
@@ -25,8 +25,8 @@ p = 50
 # Now we formulate and solve our primal problem:
 d = Variable(p)
 problem = maximize(sum(d), 0 ≤ d, d ≤ 1, Σ ⪰ Diagonal(d))
-@time solve!(problem, SCS.Optimizer; silent_solver = true)
+@time solve!(problem, SCS.Optimizer; silent = true)
 
 # To solve the dual problem instead, we simply call `dual_optimizer` on our
 # optimizer function:
-@time solve!(problem, dual_optimizer(SCS.Optimizer); silent_solver = true)
+@time solve!(problem, dual_optimizer(SCS.Optimizer); silent = true)

--- a/docs/src/examples/general_examples/huber_regression.jl
+++ b/docs/src/examples/general_examples/huber_regression.jl
@@ -40,18 +40,18 @@ for i in 1:length(p_vals)
     fit = norm(beta - beta_true) / norm(beta_true)
     cost = norm(X' * beta - Y)
     prob = minimize(cost)
-    solve!(prob, SCS.Optimizer; silent_solver = true)
+    solve!(prob, SCS.Optimizer; silent = true)
     lsq_data[i] = evaluate(fit)
 
     ## Form and solve a prescient regression problem,
     ## that is, where the sign changes are known.
     cost = norm(factor .* (X' * beta) - Y)
-    solve!(minimize(cost), SCS.Optimizer; silent_solver = true)
+    solve!(minimize(cost), SCS.Optimizer; silent = true)
     prescient_data[i] = evaluate(fit)
 
     ## Form and solve the Huber regression problem.
     cost = sum(huber(X' * beta - Y, 1))
-    solve!(minimize(cost), SCS.Optimizer; silent_solver = true)
+    solve!(minimize(cost), SCS.Optimizer; silent = true)
     huber_data[i] = evaluate(fit)
 end
 

--- a/docs/src/examples/general_examples/lasso_regression.jl
+++ b/docs/src/examples/general_examples/lasso_regression.jl
@@ -66,7 +66,7 @@ function LassoEN(Y, X, γ, λ = 0)
         ## u'u/T + γ*sum(|b|) where u = Y-Xb
         problem = minimize(L1 - 2 * L2 + γ * L3)
     end
-    solve!(problem, SCS.Optimizer; silent_solver = true)
+    solve!(problem, SCS.Optimizer; silent = true)
     problem.status == Convex.MOI.OPTIMAL ? b_i = vec(evaluate(b)) : b_i = NaN
 
     return b_i, b_ls

--- a/docs/src/examples/general_examples/logistic_regression.jl
+++ b/docs/src/examples/general_examples/logistic_regression.jl
@@ -28,7 +28,7 @@ X = hcat(
 n, p = size(X)
 beta = Variable(p)
 problem = minimize(logisticloss(-Y .* (X * beta)))
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 
 # Let's see how well the model fits.
 using Plots

--- a/docs/src/examples/general_examples/max_entropy.jl
+++ b/docs/src/examples/general_examples/max_entropy.jl
@@ -23,7 +23,7 @@ b = rand(m, 1);
 
 x = Variable(n);
 problem = maximize(entropy(x), sum(x) == 1, A * x <= b)
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 
 #-
 

--- a/docs/src/examples/general_examples/optimal_advertising.jl
+++ b/docs/src/examples/general_examples/optimal_advertising.jl
@@ -45,7 +45,7 @@ D = Variable(m, n);
 Si = [min(R[i] * dot(P[i, :], D[i, :]'), B[i]) for i in 1:m];
 problem =
     maximize(sum(Si), [D >= 0, sum(D, dims = 1)' <= T, sum(D, dims = 2) >= c]);
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 
 #-
 

--- a/docs/src/examples/general_examples/robust_approx_fitting.jl
+++ b/docs/src/examples/general_examples/robust_approx_fitting.jl
@@ -41,20 +41,20 @@ x = Variable(n)
 
 # ## Case 1: nominal optimal solution
 p = minimize(norm(A * x - b, 2))
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 #-
 x_nom = evaluate(x)
 
 # ## Case 2: stochastic robust approximation
 P = 1 / 3 * B' * B;
 p = minimize(square(pos(norm(A * x - b))) + quadform(x, Symmetric(P)))
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 #-
 x_stoch = evaluate(x)
 
 # ## Case 3: worst-case robust approximation
 p = minimize(max(norm((A - B) * x - b), norm((A + B) * x - b)))
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 
 #-
 x_wc = evaluate(x)

--- a/docs/src/examples/general_examples/svm.jl
+++ b/docs/src/examples/general_examples/svm.jl
@@ -45,7 +45,7 @@ function svm(pos_data, neg_data)
         C * sum(max(1 - b + w' * neg_data, 0))
     ## Form and solve problem.
     problem = minimize(obj)
-    solve!(problem, SCS.Optimizer; silent_solver = true)
+    solve!(problem, SCS.Optimizer; silent = true)
     return evaluate(w), evaluate(b)
 end;
 

--- a/docs/src/examples/general_examples/svm_l1regularization.jl
+++ b/docs/src/examples/general_examples/svm_l1regularization.jl
@@ -34,7 +34,7 @@ beta_vals = zeros(length(beta), TRIALS);
 for i in 1:TRIALS
     lambda = lambda_vals[i]
     problem = minimize(loss / m + lambda * reg)
-    solve!(problem, SCS.Optimizer; silent_solver = true)
+    solve!(problem, SCS.Optimizer; silent = true)
     train_error[i] =
         sum(
             float(

--- a/docs/src/examples/general_examples/trade_off_curves.jl
+++ b/docs/src/examples/general_examples/trade_off_curves.jl
@@ -19,7 +19,7 @@ x = Variable(n);
 for i in 1:length(gammas)
     cost = sumsquares(A * x - b) + gammas[i] * norm(x, 1)
     problem = minimize(cost, [norm(x, Inf) <= 1])
-    solve!(problem, SCS.Optimizer; silent_solver = true)
+    solve!(problem, SCS.Optimizer; silent = true)
     x_values[:, i] = evaluate(x)
 end
 

--- a/docs/src/examples/general_examples/worst_case_analysis.jl
+++ b/docs/src/examples/general_examples/worst_case_analysis.jl
@@ -18,7 +18,7 @@ w = Variable(n);
 ret = dot(r, w);
 risk = sum(quadform(w, Sigma_nom));
 problem = minimize(risk, [sum(w) == 1, ret >= 0.1, norm(w, 1) <= 2])
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 #-
 wval = vec(evaluate(w))
 
@@ -37,7 +37,7 @@ problem = maximize(
         Delta == Delta',
     ],
 );
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 #-
 println(
     "standard deviation = ",

--- a/docs/src/examples/optimization_with_complex_variables/Fidelity in Quantum Information Theory.jl
+++ b/docs/src/examples/optimization_with_complex_variables/Fidelity in Quantum Information Theory.jl
@@ -30,7 +30,7 @@ Z = ComplexVariable(n, n)
 objective = 0.5 * real(tr(Z + Z'))
 constraint = [P Z; Z' Q] ⪰ 0
 problem = maximize(objective, constraint)
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 #-
 computed_fidelity = evaluate(objective)
 

--- a/docs/src/examples/optimization_with_complex_variables/phase_recovery_using_MaxCut.jl
+++ b/docs/src/examples/optimization_with_complex_variables/phase_recovery_using_MaxCut.jl
@@ -65,7 +65,7 @@ objective = inner_product(U, M)
 c1 = diag(U) == 1
 c2 = isposdef(U)
 p = minimize(objective, c1, c2)
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 #-
 
 evaluate(U)

--- a/docs/src/examples/optimization_with_complex_variables/povm_simulation.jl
+++ b/docs/src/examples/optimization_with_complex_variables/povm_simulation.jl
@@ -63,7 +63,7 @@ function get_visibility(K)
         t * K[4] + (1 - t) * noise[4] == P[3][2] + P[5][2] + P[6][2],
     )
     p = maximize(t, constraints)
-    return solve!(p, SCS.Optimizer; silent_solver = true)
+    return solve!(p, SCS.Optimizer; silent = true)
 end
 
 # We check this function using the tetrahedron measurement (see Appendix B in [arXiv:quant-ph/0702021](https://arxiv.org/abs/quant-ph/0702021)). This measurement is non-simulable, so we expect a value below one.

--- a/docs/src/examples/optimization_with_complex_variables/power_flow_optimization.jl
+++ b/docs/src/examples/optimization_with_complex_variables/power_flow_optimization.jl
@@ -25,7 +25,7 @@ c3 = real(W[1, 1]) == 1.06^2;
 push!(c1, c2)
 push!(c1, c3)
 p = maximize(objective, c1);
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 #-
 p.optval
 

--- a/docs/src/examples/portfolio_optimization/portfolio_optimization2.jl
+++ b/docs/src/examples/portfolio_optimization/portfolio_optimization2.jl
@@ -53,7 +53,7 @@ MeanVarA = zeros(N, 2)
 for i in 1:N
     λ = λ_vals[i]
     p = minimize(λ * risk - (1 - λ) * ret, sum(w) == 1)
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     MeanVarA[i, :] = [evaluate(ret), evaluate(risk)]
 end
 
@@ -71,7 +71,7 @@ for i in 1:N
         w_lower <= w,     #w[i] is bounded
         w <= w_upper,
     )
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     MeanVarB[i, :] = [evaluate(ret), evaluate(risk)]
 end
 
@@ -102,7 +102,7 @@ for i in 1:N
         sum(w) == 1,
         (norm(w, 1) - 1) <= Lmax,
     )
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     MeanVarC[i, :] = [evaluate(ret), evaluate(risk)]
 end
 

--- a/docs/src/examples/supplemental_material/Convex.jl_intro_ISMP2015.jl
+++ b/docs/src/examples/supplemental_material/Convex.jl_intro_ISMP2015.jl
@@ -44,7 +44,7 @@ problem = minimize(
 )
 
 # Solve the problem by calling `solve!`
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 
 println("problem status is ", problem.status)
 println("optimal value is ", problem.optval)
@@ -59,7 +59,7 @@ using Interact, Plots
         square(norm(A * x - b)) + λ * square(norm(x)) + μ * norm(x, 1),
         x >= 0,
     )
-    solve!(problem, SCS.Optimizer; silent_solver = true)
+    solve!(problem, SCS.Optimizer; silent = true)
     histogram(evaluate(x), xlims = (0, 3.5), label = "x")
 end
 nothing # hide
@@ -134,7 +134,7 @@ p = minimize(objective, constraint)
 #-
 
 # Solve the problem:
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 p.status
 
 #-
@@ -182,9 +182,9 @@ problem = minimize(
     square(norm(A * x - b)) + λ * square(norm(x)) + μ * norm(x, 1),
     x >= 0,
 )
-@time solve!(problem, SCS.Optimizer; silent_solver = true)
+@time solve!(problem, SCS.Optimizer; silent = true)
 λ = 1.5
-@time solve!(problem, SCS.Optimizer; silent_solver = true)#, warmstart = true) # FIXME
+@time solve!(problem, SCS.Optimizer; silent = true)#, warmstart = true) # FIXME
 
 # # DCP examples
 

--- a/docs/src/examples/supplemental_material/paper_examples.jl
+++ b/docs/src/examples/supplemental_material/paper_examples.jl
@@ -13,7 +13,7 @@ e = 0;
     end
     p = minimize(e, x >= 1)
 end
-@time solve!(p, ECOS.Optimizer; silent_solver = true)
+@time solve!(p, ECOS.Optimizer; silent = true)
 
 # Indexing.
 println("Indexing example")
@@ -26,7 +26,7 @@ e = 0;
     end
     p = minimize(e, x >= ones(1000, 1))
 end
-@time solve!(p, ECOS.Optimizer; silent_solver = true)
+@time solve!(p, ECOS.Optimizer; silent = true)
 
 # Matrix constraints.
 println("Matrix constraint example")
@@ -37,7 +37,7 @@ b = randn(p, n);
 @time begin
     p = minimize(norm(X), A * X == b)
 end
-@time solve!(p, ECOS.Optimizer; silent_solver = true)
+@time solve!(p, ECOS.Optimizer; silent = true)
 
 # Transpose.
 println("Transpose example")
@@ -46,12 +46,12 @@ A = randn(5, 5);
 @time begin
     p = minimize(norm2(X - A), X' == X)
 end
-@time solve!(p, ECOS.Optimizer; silent_solver = true)
+@time solve!(p, ECOS.Optimizer; silent = true)
 
 n = 3
 A = randn(n, n);
 #@time begin
 X = Variable(n, n);
 p = minimize(norm(X' - A), X[1, 1] == 1);
-solve!(p, ECOS.Optimizer; silent_solver = true)
+solve!(p, ECOS.Optimizer; silent = true)
 #end

--- a/docs/src/examples/tomography/tomography.jl
+++ b/docs/src/examples/tomography/tomography.jl
@@ -62,7 +62,7 @@ pixel_colors = Variable(num_pixels)
 ## to reflect that, we minimize a norm
 objective = sumsquares(line_mat * pixel_colors - line_vals)
 problem = minimize(objective)
-solve!(problem, ECOS.Optimizer; silent_solver = true)
+solve!(problem, ECOS.Optimizer; silent = true)
 
 #-
 

--- a/docs/src/introduction/dcp.md
+++ b/docs/src/introduction/dcp.md
@@ -22,7 +22,7 @@ As a simple example, consider the problem:
 using Convex, SCS
 x = Variable();
 model_min = minimize(abs(x), [x >= 1, x <= 2]);
-solve!(model_min, SCS.Optimizer; silent_solver = true)
+solve!(model_min, SCS.Optimizer; silent = true)
 x.value
 ```
 
@@ -37,7 +37,7 @@ using Convex, SCS
 x = Variable();
 t = Variable();
 model_min_extended = minimize(t, [x >= 1, x <= 2, t >= x, t >= -x]);
-solve!(model_min_extended, SCS.Optimizer; silent_solver = true)
+solve!(model_min_extended, SCS.Optimizer; silent = true)
 x.value
 ```
 That is, we add the constraints `t >= x` and `t >= -x`, and replace `abs(x)` by
@@ -60,7 +60,7 @@ model_max = maximize(abs(x), [x >= 1, x <= 2])
 This time, `problem is DCP` reports `false`. If we attempt to solve the problem,
 an error is thrown:
 ```julia
-julia> solve!(model_max, SCS.Optimizer; silent_solver = true)
+julia> solve!(model_max, SCS.Optimizer; silent = true)
 ┌ Warning: Problem not DCP compliant: objective is not DCP
 └ @ Convex ~/.julia/dev/Convex/src/problems.jl:73
 ERROR: DCPViolationError: Expression not DCP compliant. This either means that your problem is not convex, or that we could not prove it was convex using the rules of disciplined convex programming. For a list of supported operations, see https://jump.dev/Convex.jl/stable/operations/. For help writing your problem as a disciplined convex program, please post a reproducible example on https://jump.dev/forum.
@@ -75,7 +75,7 @@ using Convex, SCS
 x = Variable();
 t = Variable();
 model_max_extended = maximize(t, [x >= 1, x <= 2, t >= x, t >= -x]);
-solve!(model_max_extended, SCS.Optimizer; silent_solver = true)
+solve!(model_max_extended, SCS.Optimizer; silent = true)
 ```
 whose solution is unbounded.
 

--- a/docs/src/introduction/quick_tutorial.md
+++ b/docs/src/introduction/quick_tutorial.md
@@ -21,7 +21,7 @@ m = 4;  n = 5
 A = randn(m, n); b = randn(m)
 x = Variable(n)
 problem = minimize(sumsquares(A * x - b), [x >= 0])
-solve!(problem, SCS.Optimizer; silent_solver = true)
+solve!(problem, SCS.Optimizer; silent = true)
 problem.status
 problem.optval
 x.value

--- a/docs/src/manual/advanced.md
+++ b/docs/src/manual/advanced.md
@@ -14,7 +14,7 @@ julia> y = Variable();
 
 julia> p = minimize(log(x) + square(y), [x >= 0, y >= 0]);
 
-julia> solve!(p, SCS.Optimizer; silent_solver = true)
+julia> solve!(p, SCS.Optimizer; silent = true)
 ┌ Warning: Problem not DCP compliant: objective is not DCP
 └ @ Convex ~/.julia/dev/Convex/src/problems.jl:73
 ERROR: DCPViolationError: Expression not DCP compliant. This either means that your problem is not convex, or that we could not prove it was convex using the rules of disciplined convex programming. For a list of supported operations, see https://jump.dev/Convex.jl/stable/operations/. For help writing your problem as a disciplined convex program, please post a reproducible example on https://jump.dev/forum.
@@ -35,7 +35,7 @@ using Convex, SCS
 x = Variable();
 constraint = x >= 0;
 p = minimize(x, [constraint]);
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 constraint.dual
 ```
 
@@ -159,7 +159,7 @@ example,
 using SCS
 p = ProbabilityVector(3)
 prob = minimize(p([1.0, 2.0, 3.0]))
-solve!(prob, SCS.Optimizer; silent_solver = false);
+solve!(prob, SCS.Optimizer; silent = false);
 evaluate(p)
 ```
 

--- a/docs/src/manual/complex-domain_optimization.md
+++ b/docs/src/manual/complex-domain_optimization.md
@@ -101,7 +101,7 @@ constraints = [
     isposdef(ρ),
   ]
 p = satisfy(constraints)
-solve!(p, SCS.Optimizer; silent_solver = true)
+solve!(p, SCS.Optimizer; silent = true)
 p.status
 ```
 

--- a/docs/src/manual/solvers.md
+++ b/docs/src/manual/solvers.md
@@ -45,10 +45,10 @@ silent_scs = MOI.OptimizerWithAttributes(SCS.Optimizer, MOI.Silent() => true)
 solve!(p, silent_scs)
 ```
 
-Another option is to use the solver-independent `silent_solver` keyword
+Another option is to use the solver-independent `silent` keyword
 argument to `solve!`:
 ```@repl solvers
-solve!(p, SCS.Optimizer; silent_solver=true)
+solve!(p, SCS.Optimizer; silent=true)
 ```
 
 See each solver's documentation for more information on solver-dependent

--- a/src/problem_depot/problem_depot.jl
+++ b/src/problem_depot/problem_depot.jl
@@ -113,7 +113,7 @@ MathOptInterface model, but not for the actual problem data.
 
 ```julia
 run_tests(exclude=[r"mip"]) do p
-    solve!(p, SCS.Optimizer; silent_solver=true)
+    solve!(p, SCS.Optimizer; silent=true)
 end
 ```
 """
@@ -167,7 +167,7 @@ MathOptInterface model, but not for the actual problem data.
 
 ```julia
 benchmark_suite(exclude=[r"mip"]) do p
-    solve!(p, SCS.Optimizer; silent_solver=true)
+    solve!(p, SCS.Optimizer; silent=true)
 end
 ```
 """

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -98,7 +98,6 @@ function solve!(
     elseif silent === nothing
         silent = false
     end
-
     if problem_vexity(p) in (ConcaveVexity(), NotDcp())
         throw(DCPViolationError())
     end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -59,7 +59,7 @@ end
     solve!(
         problem::Problem,
         optimizer_factory;
-        silent_solver = false,
+        silent = false,
         warmstart::Bool = true,
     )
 
@@ -69,7 +69,7 @@ duals (accessed by `cons.dual`), where applicable. Returns the input `problem`.
 
 Optional keyword arguments:
 
- * `silent_solver`: whether the solver should be silent (and not emit output or
+ * `silent`: whether the solver should be silent (and not emit output or
    logs) during the solution process.
  * `warmstart` (default: `false`): whether the solver should start the
    optimization from a previous optimal value (according to the current primal
@@ -78,18 +78,18 @@ Optional keyword arguments:
 function solve!(
     p::Problem,
     optimizer_factory;
-    silent_solver = false,
+    silent = false,
     warmstart::Bool = false,
 )
     if problem_vexity(p) in (ConcaveVexity(), NotDcp())
         throw(DCPViolationError())
     end
     context, (stats...) = @timed Context(p, optimizer_factory)
-    if !silent_solver
+    if !silent
         s = round(stats.time; digits = 2), Base.format_bytes(stats.bytes)
         @info "[Convex.jl] Compilation finished: $(s[1]) seconds, $(s[2]) of memory allocated"
     end
-    if silent_solver
+    if silent
         MOI.set(context.model, MOI.Silent(), true)
     end
     attr = MOI.VariablePrimalStart()

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -90,8 +90,10 @@ function solve!(
             ),
         )
     elseif silent_solver !== nothing
-        @warn "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`." maxlog =
-            1
+        @warn(
+            "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`.",
+            maxlog = 1,
+        )
         silent = silent_solver
     elseif silent === nothing
         silent = false

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -59,7 +59,7 @@ end
     solve!(
         problem::Problem,
         optimizer_factory;
-        silent = false,
+        silent::Bool = false,
         warmstart::Bool = true,
     )
 
@@ -79,7 +79,7 @@ Optional keyword arguments:
 function solve!(
     p::Problem,
     optimizer_factory;
-    silent = nothing, # to become `false` once `silent_solver` deprecation removed
+    silent::Union{Nothing,Bool} = nothing, # to become `false` once `silent_solver` deprecation removed
     warmstart::Bool = false,
     silent_solver = nothing, # deprecated
 )

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -84,13 +84,17 @@ function solve!(
     silent_solver = nothing, # deprecated
 )
     if silent_solver !== nothing && silent !== nothing
-        throw(ArgumentError("Cannot set both `silent` and `silent_solver` in `solve!`. `silent_solver` is deprecated, only set `silent`."))
+        throw(
+            ArgumentError(
+                "Cannot set both `silent` and `silent_solver` in `solve!`. `silent_solver` is deprecated, only set `silent`.",
+            ),
+        )
     elseif silent_solver !== nothing
         @warn "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`." maxlog =
             1
         silent = silent_solver
     end
-    
+
     if problem_vexity(p) in (ConcaveVexity(), NotDcp())
         throw(DCPViolationError())
     end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -93,6 +93,8 @@ function solve!(
         @warn "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`." maxlog =
             1
         silent = silent_solver
+    elseif silent === nothing
+        silent = false
     end
 
     if problem_vexity(p) in (ConcaveVexity(), NotDcp())

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -46,7 +46,7 @@ function test_EqualToConstraint_dual_minimize()
     x = Variable()
     c = 3 * x == 1
     p = minimize(2.0 * x + 1.0, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, 2 / 3; atol = 1e-4)
     return
 end
@@ -55,7 +55,7 @@ function test_EqualToConstraint_dual_maximize()
     x = Variable()
     c = 3 * x == 1
     p = maximize(2.0 * x + 1.0, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, -2 / 3; atol = 1e-4)
     return
 end
@@ -64,7 +64,7 @@ function test_EqualToConstraint_dual_complex()
     x = ComplexVariable()
     c = 3 * x == 1 - 2im
     p = minimize(real(x) + 2imag(x), [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, 1 / 3 - 2 / 3im; atol = 1e-4)
     return
 end
@@ -104,7 +104,7 @@ function test_GreaterThanConstraint_dual_minimize()
     x = Variable()
     c = 3 * x >= 1
     p = minimize(2.0 * x + 1.0, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, 2 / 3; atol = 1e-4)
     return
 end
@@ -113,7 +113,7 @@ function test_GreaterThanConstraint_dual_maximize()
     x = Variable()
     c = 1 >= 3 * x
     p = maximize(2.0 * x + 1.0, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, 2 / 3; atol = 1e-4)
     return
 end
@@ -153,7 +153,7 @@ function test_LessThanConstraint_dual_minimize()
     x = Variable()
     c = 1 <= 3 * x
     p = minimize(2.0 * x + 1.0, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, -2 / 3; atol = 1e-4)
     return
 end
@@ -162,7 +162,7 @@ function test_LessThanConstraint_dual_maximize()
     x = Variable()
     c = 3 * x <= 1
     p = maximize(2.0 * x + 1.0, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(c.dual, -2 / 3; atol = 1e-4)
     return
 end
@@ -177,7 +177,7 @@ function test_Constraint_PositiveSemidefiniteConeSquare()
     X = Variable(2, 2)
     c = Convex.Constraint{MOI.PositiveSemidefiniteConeSquare}(X)
     p = minimize(tr(X), [c, X >= [1 2; 3 4]])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(X.value, [2.25 3; 3 4]; atol = 1e-3)
     y = (c.dual + c.dual') / 2
     @test isapprox(y[1], 1; atol = 1e-3)
@@ -209,7 +209,7 @@ function test_Constraint_SecondOrderCone()
     t = Variable()
     c = Convex.Constraint{MOI.SecondOrderCone}(vcat(t, x))
     p = minimize(t, [c, x >= [2, 3, 4]])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(x.value, [2, 3, 4]; atol = 1e-3)
     t_ = sqrt(29)
     @test isapprox(t.value, t_; atol = 1e-3)
@@ -241,7 +241,7 @@ function test_Constraint_RotatedSecondOrderCone()
     t = Variable()
     c = Convex.Constraint{MOI.RotatedSecondOrderCone}(vcat(t, 1, x))
     p = minimize(t, [c, x >= [2, 3, 4]])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(x.value, [2, 3, 4]; atol = 1e-3)
     @test isapprox(t.value, 29 / 2; atol = 1e-3)
     @test isapprox(c.dual, [1, 29 / 2, -2, -3, -4]; atol = 1e-3)
@@ -259,14 +259,14 @@ function test_Constraint_ExponentialConeConstraint()
     # 1 * exp(1 / 1) <= z
     c = Convex.Constraint{MOI.ExponentialCone}(vcat(1, constant(1), z))
     p = minimize(z, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(z.value, exp(1); atol = 1e-4)
     @test isapprox(c.dual, [-exp(1), 0, 1]; atol = 1e-4)
     z = Variable()
     # 2 * exp(3 / 2) <= z
     c = Convex.Constraint{MOI.ExponentialCone}(vcat(constant(3), 2, z))
     p = minimize(z, [c])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(z.value, 2 * exp(3 / 2); atol = 1e-4)
     @test isapprox(c.dual, [-exp(3 / 2), exp(3 / 2) / 2, 1]; atol = 1e-4)
     c = Convex.Constraint{MOI.ExponentialCone}(vcat(square(z), 1, z))
@@ -284,7 +284,7 @@ function test_Constraint_RelativeEntropyConeConstraint()
     w = Variable(2)
     c = Convex.Constraint{MOI.RelativeEntropyCone}(vcat(u, v, w))
     p = minimize(u, [c, w >= 2])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(u.value, 2 * log(2 / 1) + 2 * log(2 / 2); atol = 1e-4)
     @test isapprox(c.dual, [1, 2, 1, -log(2) - 1, -1]; atol = 1e-3)
     c = Convex.Constraint{MOI.RelativeEntropyCone}(vcat(square(u), 1, u))

--- a/test/test_problem_depot.jl
+++ b/test/test_problem_depot.jl
@@ -51,12 +51,7 @@ function test_Clarabel_warmstarts()
     Convex.ProblemDepot.run_tests(;
         exclude = [r"mip", r"sdp_quantum_relative_entropy3_lowrank"],
     ) do p
-        ret = solve!(
-            p,
-            Clarabel.Optimizer;
-            silent = true,
-            warmstart = true,
-        )
+        ret = solve!(p, Clarabel.Optimizer; silent = true, warmstart = true)
         # verify post-solve printing does not error
         @test sprint(show, p) isa AbstractString
         return ret

--- a/test/test_problem_depot.jl
+++ b/test/test_problem_depot.jl
@@ -54,7 +54,7 @@ function test_Clarabel_warmstarts()
         ret = solve!(
             p,
             Clarabel.Optimizer;
-            silent_solver = true,
+            silent = true,
             warmstart = true,
         )
         # verify post-solve printing does not error
@@ -71,7 +71,7 @@ function test_Clarabel()
     Convex.ProblemDepot.run_tests(;
         exclude = [r"mip", r"sdp_quantum_relative_entropy3_lowrank"],
     ) do p
-        return solve!(p, Clarabel.Optimizer; silent_solver = true)
+        return solve!(p, Clarabel.Optimizer; silent = true)
     end
     return
 end
@@ -82,7 +82,7 @@ end
 #         exclude = [r"mip"],
 #         T = BigFloat,
 #     ) do p
-#         return solve!(p, Clarabel.Optimizer{BigFloat}; silent_solver = true)
+#         return solve!(p, Clarabel.Optimizer{BigFloat}; silent = true)
 #     end
 #     return
 # end
@@ -94,7 +94,7 @@ end
 #     # >   MathOptInterface.UnsupportedConstraint{MathOptInterface.VectorAffineFunction{Float64}, MathOptInterface.NormCone}: `MathOptInterface.VectorAffineFunction{Float64}`-in-`MathOptInterface.NormCone` constraint is not supported by the model.
 #     # Missing a bridge?
 #     Convex.ProblemDepot.run_tests(; exclude = [r"mip", r"sdp", r"rational_norm"]) do p
-#         return solve!(p, ECOS.Optimizer; silent_solver = true)
+#         return solve!(p, ECOS.Optimizer; silent = true)
 #     end
 #     return
 # end
@@ -103,7 +103,7 @@ function test_GLPK()
     # Note this is an inclusion, not exclusion;
     # we only test GLPK with MIPs, since those we can't test elsewhere.
     Convex.ProblemDepot.run_tests([r"mip"]) do p
-        return solve!(p, GLPK.Optimizer; silent_solver = true)
+        return solve!(p, GLPK.Optimizer; silent = true)
     end
     return
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1026,10 +1026,10 @@ function test_deprecation_silent_solver()
     x = Variable(2)
     p = minimize(sum(x))
     str = "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`."
-    @test_logs (:warn, str) solve!(p; silent_solver = true)
+    @test_logs (:warn, str) solve!(p, SCS.Optimizer; silent_solver = true)
 
     # Can't set both
-    @test_throws ArgumentError solve!(p; silent_solver = true, silent = false)
+    @test_throws ArgumentError solve!(p, SCS.Optimizer; silent_solver = true, silent = false)
 
     return
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1022,6 +1022,18 @@ function test_deprecation_adding_constraints()
     return
 end
 
+function test_deprecation_silent_solver()
+    x = Variable(2)
+    p = minimize(sum(x))
+    str = "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`."
+    @test_logs (:warn, str) solve!(p; silent_solver = true)
+
+    # Can't set both
+    @test_throws ArgumentError solve!(p; silent_solver = true, silent=false)
+
+    return
+end
+
 function test_dcp_rules()
     vexities = (
         Convex.ConcaveVexity(),

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1029,7 +1029,12 @@ function test_deprecation_silent_solver()
     @test_logs (:warn, str) solve!(p, SCS.Optimizer; silent_solver = true)
 
     # Can't set both
-    @test_throws ArgumentError solve!(p, SCS.Optimizer; silent_solver = true, silent = false)
+    @test_throws ArgumentError solve!(
+        p,
+        SCS.Optimizer;
+        silent_solver = true,
+        silent = false,
+    )
 
     return
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1029,7 +1029,7 @@ function test_deprecation_silent_solver()
     @test_logs (:warn, str) solve!(p; silent_solver = true)
 
     # Can't set both
-    @test_throws ArgumentError solve!(p; silent_solver = true, silent=false)
+    @test_throws ArgumentError solve!(p; silent_solver = true, silent = false)
 
     return
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -68,7 +68,7 @@ function test_silent_solver_works()
     output_silent = solve_and_return_output(
         p,
         MOI.OptimizerWithAttributes(SCS.Optimizer, "eps_abs" => 1e-6),
-        silent_solver = true,
+        silent = true,
     )
     @test output_silent == ""
     return
@@ -1236,16 +1236,16 @@ end
 function test_scalar_fn_constant_objective()
     x = Variable()
     p = minimize(2.1, [x >= 1])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(p.optval, 2.1; atol = 1e-5)
     p = minimize(2.2, x >= 1)
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(p.optval, 2.2; atol = 1e-5)
     p = maximize(2.3, [x >= 1])
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(p.optval, 2.3; atol = 1e-5)
     p = maximize(2.4, x >= 1)
-    solve!(p, SCS.Optimizer; silent_solver = true)
+    solve!(p, SCS.Optimizer; silent = true)
     @test isapprox(p.optval, 2.4; atol = 1e-5)
     return
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1027,7 +1027,6 @@ function test_deprecation_silent_solver()
     p = minimize(sum(x))
     str = "The keyword argument `silent_solver` in `Convex.solve!` has been deprecated in favor of `silent`."
     @test_logs (:warn, str) solve!(p, SCS.Optimizer; silent_solver = true)
-
     # Can't set both
     @test_throws ArgumentError solve!(
         p,
@@ -1035,7 +1034,6 @@ function test_deprecation_silent_solver()
         silent_solver = true,
         silent = false,
     )
-
     return
 end
 


### PR DESCRIPTION
Since now it is being used for Convex's verbosity also (printing the formulation time). It is also shorter which I like. I also set it to turn off the warning for non-optimal solutions for consistency and to reduce clutter in test logs.