### PR TITLE
Update quantum_conditional_entropy.jl to use kwarg `silent`

### DIFF
--- a/docs/src/examples/optimization_with_complex_variables/quantum_conditional_entropy.jl
+++ b/docs/src/examples/optimization_with_complex_variables/quantum_conditional_entropy.jl
@@ -79,7 +79,7 @@ problem = maximize(
     0.5 * nuclearnorm(ρ_AB - σ_AB) ≤ ϵ,
 )
 
-solve!(problem, SCS.Optimizer; silent_solver = false)
+solve!(problem, SCS.Optimizer; silent = false)
 
 # We can then check the observed difference in relative entropies:
 


### PR DESCRIPTION
following #670 