### PR TITLE
`lieb_ando`: use partially specified problem to get correct `vexity`

### DIFF
--- a/docs/src/developer/contributing.md
+++ b/docs/src/developer/contributing.md
@@ -46,10 +46,10 @@ Convex.jl. Let's say you're adding the new function $f$.
      since then any changes to the variable's value (or it being `free!`'d) will not be recognized.
      See [#653](https://github.com/jump-dev/Convex.jl/issues/653) and [#585](https://github.com/jump-dev/Convex.jl/issues/585)
      for previous bugs caused by misuse here.
- -  Do not add constraints to variables directly during a reformulation.
-    Instead, create an atom to control the vexity, or return a partially
-    specified problem: `minimize(var, constraints...)`, to ensure the `vexity`
-    of the result is correct.
+ -   Do not add constraints to variables directly during a reformulation.
+     Instead, create an atom to control the vexity, or return a partially
+     specified problem: `minimize(var, constraints...)`, to ensure the `vexity`
+     of the result is correct.
  -   The most mathematically interesting part is the `new_conic_form!`
      function. Following the example in the nuclear norm atom, you'll
      see that you can just construct the problem whose optimal value is

--- a/docs/src/developer/contributing.md
+++ b/docs/src/developer/contributing.md
@@ -46,7 +46,10 @@ Convex.jl. Let's say you're adding the new function $f$.
      since then any changes to the variable's value (or it being `free!`'d) will not be recognized.
      See [#653](https://github.com/jump-dev/Convex.jl/issues/653) and [#585](https://github.com/jump-dev/Convex.jl/issues/585)
      for previous bugs caused by misuse here.
- -  Do not add constraints to variables directly during a reformulation. Instead, create an atom to control the vexity, or return a partially-specified problem: `minimize(var, constraints...)`, to ensure the `vexity` of the result is correct.
+ -  Do not add constraints to variables directly during a reformulation.
+    Instead, create an atom to control the vexity, or return a partially
+    specified problem: `minimize(var, constraints...)`, to ensure the `vexity`
+    of the result is correct.
  -   The most mathematically interesting part is the `new_conic_form!`
      function. Following the example in the nuclear norm atom, you'll
      see that you can just construct the problem whose optimal value is

--- a/docs/src/developer/contributing.md
+++ b/docs/src/developer/contributing.md
@@ -46,6 +46,7 @@ Convex.jl. Let's say you're adding the new function $f$.
      since then any changes to the variable's value (or it being `free!`'d) will not be recognized.
      See [#653](https://github.com/jump-dev/Convex.jl/issues/653) and [#585](https://github.com/jump-dev/Convex.jl/issues/585)
      for previous bugs caused by misuse here.
+ -  Do not add constraints to variables directly during a reformulation. Instead, create an atom to control the vexity, or return a partially-specified problem: `minimize(var, constraints...)`, to ensure the `vexity` of the result is correct.
  -   The most mathematically interesting part is the `new_conic_form!`
      function. Following the example in the nuclear norm atom, you'll
      see that you can just construct the problem whose optimal value is

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -1935,6 +1935,11 @@ end
                 end
                 handle_problem!(p)
                 if test
+                    if t >= 0 && t <= 1
+                        @test vexity(objective) in ConvexVexity()
+                    else
+                        @test vexity(objective) == ConcaveVexity()
+                    end
                     @test p.optval ≈ QtAB atol = atol * 5 rtol = rtol
                 end
 
@@ -1946,6 +1951,11 @@ end
                 end
                 handle_problem!(p)
                 if test
+                    if t >= 0 && t <= 1
+                        @test vexity(objective) in ConvexVexity()
+                    else
+                        @test vexity(objective) == ConcaveVexity()
+                    end
                     @test p.optval ≈ QtAB atol = atol * 5 rtol = rtol
                 end
 

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -1952,9 +1952,9 @@ end
                 handle_problem!(p)
                 if test
                     if t >= 0 && t <= 1
-                        @test vexity(objective) in ConvexVexity()
-                    else
                         @test vexity(objective) == ConcaveVexity()
+                    else
+                        @test vexity(objective) in ConvexVexity()
                     end
                     @test p.optval ≈ QtAB atol = atol * 5 rtol = rtol
                 end

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -1935,26 +1935,26 @@ end
                 end
                 handle_problem!(p)
                 if test
-                    if t >= 0 && t <= 1
-                        @test vexity(objective) in ConvexVexity()
-                    else
+                    if 0 <= t <= 1
                         @test vexity(objective) == ConcaveVexity()
+                    else
+                        @test vexity(objective) == ConvexVexity()
                     end
                     @test p.optval ≈ QtAB atol = atol * 5 rtol = rtol
                 end
 
                 objective = lieb_ando(A, Y, eye(n), t)
-                if t >= 0 && t <= 1
+                if 0 <= t <= 1
                     p = maximize(objective, [Y == B]; numeric_type = T)
                 else
                     p = minimize(objective, [Y == B]; numeric_type = T)
                 end
                 handle_problem!(p)
                 if test
-                    if t >= 0 && t <= 1
+                    if 0 <= t <= 1
                         @test vexity(objective) == ConcaveVexity()
                     else
-                        @test vexity(objective) in ConvexVexity()
+                        @test vexity(objective) == ConvexVexity()
                     end
                     @test p.optval ≈ QtAB atol = atol * 5 rtol = rtol
                 end

--- a/src/reformulations/lieb_ando.jl
+++ b/src/reformulations/lieb_ando.jl
@@ -88,24 +88,18 @@ function lieb_ando(
 
     if t >= 0 && t <= 1
         # Concave function
-        add_constraint!(
-            T,
-            Constraint(
-                (T, kron(A, Im), kron(In, conj(B))),
-                GeometricMeanHypoConeSquare(t, n * m, false),
-            ),
+        constraint = Constraint(
+            (T, kron(A, Im), kron(In, conj(B))),
+            GeometricMeanHypoConeSquare(t, n * m, false),
         )
-        return real(LinearAlgebra.tr(KvKv * T))
+        return maximize(real(LinearAlgebra.tr(KvKv * T)), constraint)
     elseif (t >= -1 && t <= 0) || (t >= 1 && t <= 2)
         # Convex function
-        add_constraint!(
-            T,
-            Convex.Constraint(
-                (T, kron(A, Im), kron(In, conj(B))),
-                GeometricMeanEpiConeSquare(t, size(T, 1)),
-            ),
+        constraint = Convex.Constraint(
+            (T, kron(A, Im), kron(In, conj(B))),
+            GeometricMeanEpiConeSquare(t, size(T, 1)),
         )
-        return real(LinearAlgebra.tr(KvKv * T))
+        return minimize(real(LinearAlgebra.tr(KvKv * T)), constraint)
     else
         throw(DomainError(t, "t must be between -1 and 2"))
     end


### PR DESCRIPTION
This is in fact the approach used in CVXQUAD (https://github.com/hfawzi/cvxquad/blob/master/lieb_ando.m), but we didn't have those yet at the time.

This way we don't have to create an atom! Pretty convenient.

Also: I noticed in many of the CVXQUAD-derived atoms, we expect some variables to be PSD, but don't check or enforce it. Could be something we might want to do.

closes #683 