### PR TITLE
change `LogSumExp` atom to be per-column, for efficient `logisticloss`

### DIFF
--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -129,6 +129,23 @@ end
     if test
         @test p.optval ≈ log(exp(1) * 5) atol = atol rtol = rtol
     end
+
+    y = Variable(5, 2)
+    p = minimize(sum(Convex.ColwiseLogSumExpAtom(y)), y[:, 1] >= 1, y[:, 2] >= 2; numeric_type = T)
+    handle_problem!(p)
+    if test
+        @test evaluate(y[:, 1]) ≈ ones(5) atol = atol rtol = rtol
+        @test evaluate(y[:, 2]) ≈ 2*ones(5) atol = atol rtol = rtol
+        @test p.optval ≈ log(exp(1) * 5) + log(exp(2) * 5) atol = atol rtol = rtol
+    end
+
+    p = minimize(logsumexp(y), y[:, 1] >= 1, y[:, 2] >= 2; numeric_type = T)
+    handle_problem!(p)
+    if test
+        @test evaluate(y[:, 1]) ≈ ones(5) atol = atol rtol = rtol
+        @test evaluate(y[:, 2]) ≈ 2*ones(5) atol = atol rtol = rtol
+        @test p.optval ≈ log(exp(1) * 5 + exp(2)*5) atol = atol rtol = rtol
+    end
 end
 
 @add_problem exp function exp_logistic_loss_atom(

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -155,7 +155,7 @@ end
 
     x = Variable(2, 3)
     v = Convex.ColwiseLogSumExpAtom(x)
-    p = minimize(sum(v), x >= [1 2 3; 4 5 6])
+    p = minimize(sum(v), x >= [1 2 3; 4 5 6]; numeric_type = T)
     handle_problem!(p)
     if test
         @test evaluate(x) ≈ [1 2 3; 4 5 6] atol = atol rtol = rtol

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -152,6 +152,16 @@ end
         @test evaluate(y[:, 2]) ≈ 2 * ones(5) atol = atol rtol = rtol
         @test p.optval ≈ log(exp(1) * 5 + exp(2) * 5) atol = atol rtol = rtol
     end
+
+    x = Variable(2, 3)
+    v = Convex.ColwiseLogSumExpAtom(x)
+    p = minimize(sum(v), x >= [1 2 3; 4 5 6])
+    handle_problem!(p)
+    if test
+        @test evaluate(x) ≈ [1 2 3; 4 5 6] atol = atol rtol = rtol
+        @test evaluate(v) ≈ [log(sum(exp, col)) for col in eachcol(evaluate(x))] atol = atol rtol = rtol
+        @test vexity(v) == Convex.ConvexVexity()
+    end
 end
 
 @add_problem exp function exp_logistic_loss_atom(

--- a/src/problem_depot/problems/exp.jl
+++ b/src/problem_depot/problems/exp.jl
@@ -131,20 +131,26 @@ end
     end
 
     y = Variable(5, 2)
-    p = minimize(sum(Convex.ColwiseLogSumExpAtom(y)), y[:, 1] >= 1, y[:, 2] >= 2; numeric_type = T)
+    p = minimize(
+        sum(Convex.ColwiseLogSumExpAtom(y)),
+        y[:, 1] >= 1,
+        y[:, 2] >= 2;
+        numeric_type = T,
+    )
     handle_problem!(p)
     if test
         @test evaluate(y[:, 1]) ≈ ones(5) atol = atol rtol = rtol
-        @test evaluate(y[:, 2]) ≈ 2*ones(5) atol = atol rtol = rtol
-        @test p.optval ≈ log(exp(1) * 5) + log(exp(2) * 5) atol = atol rtol = rtol
+        @test evaluate(y[:, 2]) ≈ 2 * ones(5) atol = atol rtol = rtol
+        @test p.optval ≈ log(exp(1) * 5) + log(exp(2) * 5) atol = atol rtol =
+            rtol
     end
 
     p = minimize(logsumexp(y), y[:, 1] >= 1, y[:, 2] >= 2; numeric_type = T)
     handle_problem!(p)
     if test
         @test evaluate(y[:, 1]) ≈ ones(5) atol = atol rtol = rtol
-        @test evaluate(y[:, 2]) ≈ 2*ones(5) atol = atol rtol = rtol
-        @test p.optval ≈ log(exp(1) * 5 + exp(2)*5) atol = atol rtol = rtol
+        @test evaluate(y[:, 2]) ≈ 2 * ones(5) atol = atol rtol = rtol
+        @test p.optval ≈ log(exp(1) * 5 + exp(2) * 5) atol = atol rtol = rtol
     end
 end
 

--- a/test/test_atoms.jl
+++ b/test/test_atoms.jl
@@ -1093,7 +1093,7 @@ end
 
 ### exp_cone/LogSumExp
 
-function test_LogSumExpAtom()
+function test_ColwiseLogSumExpAtom()
     target = """
     variables: x1, x2, t, z1, z2
     minobjective: 1.0 * t
@@ -1115,21 +1115,20 @@ function test_LogSumExpAtom()
         return logisticloss(Variable())
     end
     target = """
-    variables: x1, x1_, t, z1, z2, t_, z1_, z2_
+    variables: x1, x1_, t, t_, z1, z2, z1_, z2_
     minobjective: 1.0 * t + 1.0 * t_
     [1.0 * x1 + -1.0 * t, 1.0, 1.0 * z1] in ExponentialCone()
     [-1.0 * t, 1.0, 1.0 * z2] in ExponentialCone()
     [1.0 * x1_ + -1.0 * t_, 1.0, 1.0 * z1_] in ExponentialCone()
     [-1.0 * t_, 1.0, 1.0 * z2_] in ExponentialCone()
-    [1.0 + -1.0*z1 + -1.0*z2] in Nonnegatives(1)
-    [1.0 + -1.0*z1_ + -1.0*z2_] in Nonnegatives(1)
+    [1.0 + -1.0*z1 + -1.0*z2, 1.0 + -1.0*z1_ + -1.0*z2_] in Nonnegatives(2)
     """
     _test_atom(target) do context
         return logisticloss(Variable(2))
     end
     @test_throws(
         ErrorException(
-            "[LogSumExpAtom] the argument should be real but it's instead complex",
+            "[ColwiseLogSumExpAtom] the argument should be real but it's instead complex",
         ),
         logsumexp(im * Variable()),
     )


### PR DESCRIPTION
closes #682 

the actual atom was never documented, only `logsumexp`, so this should be non-breaking