### PR TITLE
Update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Convex.jl
 
-[![Build Status](https://github.com/jump-dev/Convex.jl/workflows/CI/badge.svg)](https://github.com/jump-dev/Convex.jl/actions?query=workflow%3ACI)
+[![CI](https://github.com/jump-dev/Convex.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/jump-dev/Convex.jl/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/jump-dev/Convex.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jump-dev/Convex.jl)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://jump.dev/Convex.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://jump.dev/Convex.jl/dev)


### PR DESCRIPTION
I believe the current badge shows failing if the latest CI run was on a PR that was failing (maybe? I believe I saw this a few days ago at least). This one I got from github by going to https://github.com/jump-dev/Convex.jl/actions/workflows/ci.yml, clicking the 3 dots, and "create status badge": 
<img width="550" alt="Screenshot 2024-05-24 at 14 35 46" src="https://github.com/jump-dev/Convex.jl/assets/5846501/21b6d7fa-37c3-449d-a029-9e5cef1c34d2">

This changes the name to `CI`, but I kinda think that is better than "build status".

xref https://github.com/actions/starter-workflows/issues/1525#issuecomment-1763431305