### PR TITLE
Add a Warning to Avoid Julia's Broadcatisng in Expressions

### DIFF
--- a/docs/src/manual/types.md
+++ b/docs/src/manual/types.md
@@ -86,7 +86,9 @@ evaluate(expr)
 ```
 
 !!! warning
-    Julia's broadcasting, using the `.` operator should be avoided. The expression `-log(1.0 .+ A * x)` will fail while `-log(1.0 + A * x)` will be correctly encoded. 
+    Avoid using Julia's broadcasting (the `.` operator). As an example, the
+    expression `-log(1.0 .+ A * x)` will fail while `-log(1.0 + A * x)` will
+    succeed.
 
 ## Constraints
 

--- a/docs/src/manual/types.md
+++ b/docs/src/manual/types.md
@@ -84,6 +84,7 @@ solve!(problem, SCS.Optimizer)
 # Once the problem is solved, we can call evaluate() on expr:
 evaluate(expr)
 ```
+!!! warning Julia's broadcasting, using the `.` operator should be avoided. The expression `-log(1.0 .+ A * x)` will fail while `-log(1.0 + A * x)` will be correctly encoded. 
 
 ## Constraints
 

--- a/docs/src/manual/types.md
+++ b/docs/src/manual/types.md
@@ -84,7 +84,9 @@ solve!(problem, SCS.Optimizer)
 # Once the problem is solved, we can call evaluate() on expr:
 evaluate(expr)
 ```
-!!! warning Julia's broadcasting, using the `.` operator should be avoided. The expression `-log(1.0 .+ A * x)` will fail while `-log(1.0 + A * x)` will be correctly encoded. 
+
+!!! warning
+    Julia's broadcasting, using the `.` operator should be avoided. The expression `-log(1.0 .+ A * x)` will fail while `-log(1.0 + A * x)` will be correctly encoded. 
 
 ## Constraints
 


### PR DESCRIPTION
Adding a warning to avoid using `.` in expressions.

Closes https://github.com/jump-dev/Convex.jl/issues/716.