### PR TITLE
DNM: test doc CI after rotating DOCUMENTER_KEY

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@
 # in the LICENSE file or at https://opensource.org/license/bsd-2-clause
 
 using Convex
+
 import Documenter
 import Literate
 import Test


### PR DESCRIPTION
This is just a test PR.

I'm in the process of centralizing how we manage our various secrets and deploy keys. We currently have a bunch of repos using different `DOCUMENTER_KEY`s, which makes it hard to know which ones have access, and we don't have an easy way to update them or revoke them without going through a bunch of individual settings. 